### PR TITLE
fix(ui): Fix visual bug, overlapping with nav bar and search bar

### DIFF
--- a/src/components/map/map_wrapper.tsx
+++ b/src/components/map/map_wrapper.tsx
@@ -98,8 +98,8 @@ export default function MapWrapper({
         <div
           className={`
             bg-white/95 backdrop-blur-xl rounded-2xl shadow-2xl
-            w-[calc(100vw-2rem)] sm:w-[340px]
-            max-h-[calc(100vh-11rem)] sm:max-h-[calc(100vh-12rem)]
+            w-full sm:w-[340px]
+            max-h-[70vh] sm:max-h-[60vh]
             min-h-0
             flex flex-col
             transition-all duration-300 origin-bottom

--- a/src/components/map/map_wrapper.tsx
+++ b/src/components/map/map_wrapper.tsx
@@ -93,7 +93,8 @@ export default function MapWrapper({
           className={`
             bg-white/95 backdrop-blur-xl rounded-2xl shadow-2xl
             w-[calc(100vw-2rem)] sm:w-[340px]
-            max-h-[calc(100vh-6rem)] sm:max-h-[calc(100vh-8rem)]
+            max-h-[calc(100vh-11rem)] sm:max-h-[calc(100vh-12rem)]
+            min-h-0
             flex flex-col
             transition-all duration-300 origin-bottom-left 
             border border-white/30


### PR DESCRIPTION
## Summary
Resolves two overlapping UI issues on the map page: the layers panel no longer overlaps the navbar and search bar, and the search bar no longer overlaps the layers panel.

## Changes

### 1. Layers panel vs navbar & search bar
- **Issue:** The layers panel (bottom-left) could grow tall enough to cover the navbar and search bar.
- **Fix:** Limited the panel height so it stays below the top area:
  - **Max height:** `max-h-[calc(100vh-11rem)]` (mobile), `sm:max-h-[calc(100vh-12rem)]` (desktop) so the panel stops ~11–12rem from the top and no longer reaches the navbar (~7rem) or search bar (~7rem + height).
- **Layout:** Added `min-h-0` on the panel so the flex child can shrink and the inner `overflow-y-auto` scrolls correctly instead of expanding the panel.

### 2. Search bar vs layers panel
- **Issue:** Search bar (top-left) and layers panel (bottom-left) shared the left side and overlapped when the panel was open.
- **Fix:** Moved the search bar to the **top-right** on the map page:
  - **Before:** `absolute top-28 left-8 w-80 z-10`
  - **After:** `absolute top-28 right-8 left-auto w-80 max-w-[calc(100vw-4rem)] z-10`
- Search stays below the navbar; `max-w-[calc(100vw-4rem)]` keeps it within the viewport on small screens. Only the map page was changed; other pages (e.g. green solutions) keep their existing search position.

## Files touched
- `src/components/map/map_wrapper.tsx` – layers panel max-height and `min-h-0`
- `src/app/map_page/page.tsx` – search bar position (right-8, left-auto, max-width)

## Testing
- [ ] Open map page, open layers panel: panel stays below navbar and search bar and does not cover them.
- [ ] Search bar is visible and usable in the top-right; layers panel in bottom-left; no overlap when panel is open.
- [ ] On narrow viewports, search bar stays on screen and panel still scrolls internally when content is long.
- [ ] Green solutions (or other pages using MapWrapper) still show search in their intended position.
