### PR TITLE
chore(dashboard): Cleaned up the code for the dashboard

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import { useState, useRef, useEffect, useCallback, Suspense } from "react";
+import Image from "next/image";
+import dynamic from "next/dynamic";
+import mapboxgl from "mapbox-gl";
+import exifr from "exifr";
+import { useSearchParams } from "next/navigation";
 import Navbar from "@/components/ui/general/layout/navbar";
 import {
   MapPin,
@@ -12,22 +18,19 @@ import {
   Thermometer,
 } from "lucide-react";
 import GreenSolutionCard from "@/components/ui/general/cards/greensolution-infocard";
-import { useState, useRef, useEffect, useCallback, Suspense } from "react";
-import mapboxgl from "mapbox-gl";
 import {
   BarangayProvider,
   useBarangay,
-  BarangayData,
+  type BarangayData,
 } from "@/context/BarangayContext";
-import exifr from "exifr";
-import Image from "next/image";
-import dynamic from "next/dynamic";
-import { useSearchParams } from "next/navigation";
 import { getGreeneryClassColor } from "@/lib/chloroplet-colors";
 import BarangayMetricItem from "./barangaydetails";
 import { type LocationSelectionMode } from "@/types/maplayers";
-import { SelectedFeature } from "@/types/metrics";
-import { GreenRecommendation, SidebarView } from "@/types/green_solutions";
+import type { SelectedFeature } from "@/types/metrics";
+import {
+  type GreenRecommendation,
+  type SidebarView,
+} from "@/types/green_solutions";
 import SidebarDetail from "@/components/ui/green_solutions/SidebarDetails";
 
 const RECOMMENDATIONS: GreenRecommendation[] = [
@@ -75,16 +78,16 @@ const RECOMMENDATIONS: GreenRecommendation[] = [
 const MapWrapper = dynamic(() => import("@/components/map/map_wrapper"), {
   ssr: false,
   loading: () => (
-    <div className="w-full h-full flex items-center justify-center bg-neutral-50 rounded-xl border-2 border-dashed border-neutral-200">
-      <div className="text-neutral-400 flex flex-col items-center gap-2">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-green" />
+    <div className="flex h-full w-full items-center justify-center rounded-xl border-2 border-dashed border-neutral-200 bg-neutral-50">
+      <div className="flex flex-col items-center gap-2 text-neutral-400">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary-green" />
         <span className="font-medium">Initializing Map...</span>
       </div>
     </div>
   ),
 });
 
-function MetricsDashboard() {
+function ExploreMetricsDashboard() {
   const { selectedBarangay } = useBarangay();
   if (!selectedBarangay) return null;
 
@@ -92,24 +95,24 @@ function MetricsDashboard() {
   const [textColor, bgColor] = classColor.split(" ");
 
   return (
-    <div className="flex flex-col items-center gap-3 w-full animate-in fade-in slide-in-from-top-2 duration-500">
+    <div className="flex w-full flex-col items-center gap-3 animate-in fade-in slide-in-from-top-2 duration-500">
       <h3
-        className={`w-full ${bgColor} ${textColor} text-[10px] sm:text-xs font-black rounded-xl py-1.5 px-3 text-center uppercase tracking-widest`}
+        className={`w-full ${bgColor} ${textColor} rounded-xl py-1.5 px-3 text-center text-[10px] font-black uppercase tracking-widest sm:text-xs`}
       >
         {selectedBarangay.name
           ? `${selectedBarangay.name} Statistics`
           : "Regional Overview"}
       </h3>
 
-      <div className="grid grid-cols-2 gap-2 w-full">
+      <div className="grid w-full grid-cols-2 gap-2">
         <BarangayMetricItem
           icon={Leaf}
-          label="Greenery"
+          label="Greenery Index"
           value={selectedBarangay.greeneryIndex ?? 0}
         />
         <BarangayMetricItem
           icon={Trees}
-          label="Canopy"
+          label="Tree Canopy"
           value={selectedBarangay.treeCanopy ?? 0}
         />
         <BarangayMetricItem
@@ -119,7 +122,7 @@ function MetricsDashboard() {
         />
         <BarangayMetricItem
           icon={Thermometer}
-          label="Heat"
+          label="Surface Temp"
           value={selectedBarangay.lst ?? 0}
           isTemperature
         />
@@ -213,18 +216,21 @@ export default function ExplorePage() {
   useEffect(() => {
     fetch("/geo/mandaue_barangays_gi.geojson")
       .then((res) => res.json())
-      .then((data: any) => {
+      .then((data: GeoJSON.FeatureCollection) => {
         const mapped =
-          data.features?.map((f: any) => ({
-            name: f.properties.name,
-            greeneryIndex: f.properties.greenery_index,
-            ndvi: f.properties.ndvi,
-            lst: f.properties.lst,
-            treeCanopy: f.properties.tree_canopy,
-            floodExposure: f.properties.flood_exposure,
-            currentIntervention: f.properties.current_intervention,
-          })) || [];
+          data.features?.map((feature) => ({
+            name: feature.properties?.name as string | undefined,
+            greeneryIndex: (feature.properties?.greenery_index as number | undefined) ?? 0,
+            ndvi: (feature.properties?.ndvi as number | undefined) ?? 0,
+            lst: (feature.properties?.lst as number | undefined) ?? 0,
+            treeCanopy: (feature.properties?.tree_canopy as number | undefined) ?? 0,
+            floodExposure: feature.properties?.flood_exposure as string | undefined,
+            currentIntervention: feature.properties?.current_intervention as string | undefined,
+          })) ?? [];
         setGeoData(mapped);
+      })
+      .catch((error) => {
+        console.error("Failed to load barangay geo data:", error);
       });
   }, []);
 
@@ -318,8 +324,8 @@ export default function ExplorePage() {
     });
   }, [selectedFeature]);
 
-  const handleFeatureSelected = useCallback((f: SelectedFeature) => {
-    setSelectedFeature(f);
+  const handleFeatureSelected = useCallback((feature: SelectedFeature) => {
+    setSelectedFeature(feature);
   }, []);
 
   return (
@@ -420,7 +426,7 @@ export default function ExplorePage() {
                 />
               ) : (
                 <>
-                  <MetricsDashboard />
+                  <ExploreMetricsDashboard />
 
                   <div className="space-y-5">
                     <div className="flex items-center gap-4">
@@ -559,7 +565,7 @@ export default function ExplorePage() {
                     />
                   ) : (
                     <>
-                      <MetricsDashboard />
+                      <ExploreMetricsDashboard />
 
                       <div className="space-y-3 pb-6">
                         <div className="flex items-center gap-3">

--- a/src/app/home_dashboard/page.tsx
+++ b/src/app/home_dashboard/page.tsx
@@ -1,75 +1,103 @@
-"use client"
+"use client";
 
-import Navbar from "@/components/ui/general/layout/navbar"
-import IndicatorCard from "@/components/ui/dashboard/indicatorcard"
-import { Download, Filter, MapPinned } from "lucide-react"
-import InterventionAnalysisTable from "@/components/ui/dashboard/InterventionAnalysisTable"
-import CityGreeneryMap from "@/components/ui/dashboard/CityGreeneryMap"
+import { useEffect, useMemo, useState } from "react";
+import { Download, MapPinned } from "lucide-react";
 
-import { BarangayProvider } from "@/context/BarangayContext"
-import { fetchMetricDescriptions } from "@/lib/api/get_definitions"
-import { useEffect, useState } from "react"
-import { MetricDescriptions } from "@/types/metrics"
+import Navbar from "@/components/ui/general/layout/navbar";
+import IndicatorCard from "@/components/ui/dashboard/indicatorcard";
+import InterventionAnalysisTable from "@/components/ui/dashboard/InterventionAnalysisTable";
+import CityGreeneryMap from "@/components/ui/dashboard/CityGreeneryMap";
+import { BarangayProvider } from "@/context/BarangayContext";
+import { fetchMetricDescriptions } from "@/lib/api/get_definitions";
+import type { MetricDescriptions } from "@/types/metrics";
+
+function useMetricDescriptions() {
+  const [metricDescriptions, setMetricDescriptions] = useState<MetricDescriptions[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function load() {
+      const data = await fetchMetricDescriptions();
+      if (!isMounted) return;
+      setMetricDescriptions(data);
+    }
+
+    void load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const getDescription = useMemo(
+    () =>
+      (name: string): string => {
+        const metric = metricDescriptions.find((item) => item.name === name);
+        if (!metric) return "";
+
+        if (metric.what || metric.why) {
+          const what = metric.what ?? "";
+          const why = metric.why ?? "";
+          return `${what}${what && why ? "\n\n" : ""}${why}`.trim();
+        }
+
+        return metric.description ?? "";
+      },
+    [metricDescriptions],
+  );
+
+  return { metricDescriptions, getDescription };
+}
 
 export default function DashboardPage() {
-  const [metricDescriptions, setMetricDescriptions] = useState<MetricDescriptions[]>([])
-  
-  const currentDate = new Date()
-  const currentMonth = currentDate.toLocaleString("default", {
-    month: "long",
-    day: "numeric",
-  })
-  
-  useEffect(() => {
-    async function load() {
-      const data = await fetchMetricDescriptions()
-      setMetricDescriptions(data)
-    }
-    load()
-  }, [])
+  const currentDate = useMemo(() => new Date(), []);
+  const currentMonthLabel = useMemo(
+    () =>
+      currentDate.toLocaleString("default", {
+        month: "long",
+        day: "numeric",
+      }),
+    [currentDate],
+  );
 
-  const getDesc = (name: string) => {
-    const metric = metricDescriptions.find((metric) => metric.name === name);
-    if (!metric) return "";
-    // Prefer explicit what/why fields when available
-    if (metric.what || metric.why) {
-      const w = metric.what ?? "";
-      const y = metric.why ?? "";
-      return `${w}${w && y ? '\n\n' : ''}${y}`.trim();
-    }
-    return metric.description || "";
-  }
+  const { getDescription } = useMetricDescriptions();
 
   return (
     <BarangayProvider>
-      <main className="min-h-screen max-w-screen px-10 relative bg-gradient-to-br from-white to-green-100 flex flex-col">
+      <main className="relative flex min-h-screen max-w-screen flex-col bg-gradient-to-br from-white to-green-100 px-4 py-8 md:px-10 md:py-12">
         <Navbar />
 
-        <div className="w-full flex flex-col overflow-hidden py-32 gap-8">
-          <div className="flex flex-col gap-4">
-            {/* Header info */}
-            <div className="flex justify-between items-center w-full">
-              <div className="flex items-center gap-3">
-                <MapPinned size={28} className="text-primary-green" />
-                <h1 className="text-neutral-black text-2xl">Mandaue City</h1>
-                <h1 className="text-neutral-black/50 text-xl">|</h1>
-                <h2 className="text-neutral-black/80 text-xl">{currentMonth}</h2>
+        <div className="flex w-full flex-1 flex-col gap-8 overflow-hidden py-6 md:py-16">
+          <section className="flex flex-col gap-4">
+            <header className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+              <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                <MapPinned size={28} className="text-primary-green" aria-hidden />
+                <h1 className="text-2xl font-semibold text-neutral-black">Mandaue City</h1>
+                <span className="hidden text-xl text-neutral-black/50 sm:inline" aria-hidden>
+                  |
+                </span>
+                <p className="text-base font-medium text-neutral-black/80 sm:text-xl">
+                  {currentMonthLabel}
+                </p>
               </div>
 
-              <button className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 flex items-center gap-2">
-                <Download className="w-4 h-4" />
-                Export
+              <button
+                type="button"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+              >
+                <Download className="h-4 w-4" aria-hidden />
+                <span>Export</span>
               </button>
-            </div>
+            </header>
 
-            {/* Metrics */}
-            <div className="flex gap-4">
+            <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
               <IndicatorCard
                 title="Greenery Index"
                 subtitle="GI (0-1 scale)"
                 value={0.68}
                 trendValue={0.05}
-                description={getDesc("GreeneryIndex")}
+                description={getDescription("GreeneryIndex")}
               />
 
               <IndicatorCard
@@ -77,7 +105,7 @@ export default function DashboardPage() {
                 subtitle="NDVI (0-1 scale)"
                 value={0.72}
                 trendValue={0.03}
-                description={getDesc("Normalized Difference Vegetation Index")}
+                description={getDescription("Normalized Difference Vegetation Index")}
               />
 
               <IndicatorCard
@@ -85,7 +113,7 @@ export default function DashboardPage() {
                 subtitle="TCC (0-1 scale)"
                 value={0.65}
                 trendValue={0.08}
-                description={getDesc("Tree Canopy Cover")}
+                description={getDescription("Tree Canopy Cover")}
               />
 
               <IndicatorCard
@@ -93,17 +121,18 @@ export default function DashboardPage() {
                 subtitle="LST (°C)"
                 value={32}
                 trendValue={1}
-                LST={true}
-                description={getDesc("Land Surface Temperature")}
+                isLST
+                description={getDescription("Land Surface Temperature")}
               />
-            </div>
-          </div>
+            </section>
+          </section>
 
-          {/* Map + Table */}
-          <CityGreeneryMap />
-          <InterventionAnalysisTable />
+          <section className="flex flex-col gap-6">
+            <CityGreeneryMap />
+            <InterventionAnalysisTable />
+          </section>
         </div>
       </main>
     </BarangayProvider>
-  )
+  );
 }

--- a/src/components/ui/dashboard/CityGreeneryMap.tsx
+++ b/src/components/ui/dashboard/CityGreeneryMap.tsx
@@ -1,62 +1,103 @@
-"use client"
+"use client";
 
-import BarangayGreenery from "./BarangayGreenerayDetails";
-import BarangayGreeneryPage from "@/app/home_dashboard/barangays_greenery/[id]/page"
-import { Leaf, Sprout, Thermometer, TreeDeciduous, ChevronsDown, ChevronsUp } from "lucide-react";
-import { Info } from "lucide-react";
 import * as React from "react";
+import {
+  Leaf,
+  Sprout,
+  Thermometer,
+  TreeDeciduous,
+  ChevronsDown,
+  ChevronsUp,
+  Info,
+} from "lucide-react";
+
 import { useBarangay } from "@/context/BarangayContext";
+import { getGreeneryClassColor } from "@/lib/chloroplet-colors";
 
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@/components/ui/collapsible"
-import ChoroplethMap from "./ChloropletMap"
-import { getGreeneryClassColor } from "@/lib/chloroplet-colors"
+} from "@/components/ui/collapsible";
 import { Button } from "../button";
+import BarangayGreenery from "./BarangayGreenerayDetails";
+import ChoroplethMap from "./ChloropletMap";
 
 export default function CityGreeneryMap() {
-  const [isOpen, setIsOpen] = React.useState(false)
+  const [isOpen, setIsOpen] = React.useState(false);
   const { selectedBarangay } = useBarangay();
-  const classColor = getGreeneryClassColor(selectedBarangay?.greeneryIndex || 0);
-  const [textColor, bgColor] = classColor.split(' ');
+
+  const greeneryClassColor = getGreeneryClassColor(selectedBarangay?.greeneryIndex ?? 0);
+  const [textColor, bgColor] = greeneryClassColor.split(" ");
+
+  const effectiveTextColor =
+    textColor === "text-green-600"
+      ? "#16a34a"
+      : textColor === "text-lime-600"
+        ? "#65a30d"
+        : textColor === "text-yellow-600"
+          ? "#ca8a04"
+          : textColor === "text-red-600"
+            ? "#dc2626"
+            : "#4b5563";
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="flex-1 flex flex-col">
-      <div className="flex flex-col gap-4 flex-1">
-        <h1 className="text-neutral-black text-xl font-medium">Citywide Greenery Map</h1>
-        <div className="flex flex-row  flex-1 w-full border rounded-lg">
-          <div className="w-2/3 flex overflow-hidden rounded-l-lg shadow-md ">                
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="flex flex-1 flex-col"
+    >
+      <div className="flex flex-1 flex-col gap-4">
+        <h2 className="text-xl font-medium text-neutral-black">
+          Citywide Greenery Map
+        </h2>
+        <div className="flex w-full flex-1 flex-col overflow-hidden rounded-lg border bg-white shadow-sm md:flex-row">
+          <div className="h-72 w-full overflow-hidden border-b md:h-auto md:w-2/3 md:border-b-0 md:border-r">
             <ChoroplethMap />
           </div>
-          <div className="flex flex-col w-1/3 p-4 px-6 flex-1 items-center bg-white rounded-r-lg shadow-md gap-4">
-            <div className="flex flex-row w-full items-center gap-2">
-              <Info size={24} className="text-neutral-black/50" />
-              <h3 className="text-neutral-black/50 text-md font-medium font-poppins">Barangay Environmental Metrics</h3>
+          <aside className="flex w-full flex-1 flex-col items-center gap-4 bg-white p-4 px-6 md:w-1/3">
+            <div className="flex w-full items-center gap-2">
+              <Info size={24} className="text-neutral-black/50" aria-hidden />
+              <h3 className="font-poppins text-md font-medium text-neutral-black/70">
+                Barangay Environmental Metrics
+              </h3>
             </div>
-            <h1 className={`w-fit ${bgColor} text-xl font-bold rounded-sm py-1 px-4 ${textColor}`}>{selectedBarangay?.name || "Select a Barangay"}</h1>
-            <hr className="border-neutral-grey w-full" />
-            <div className="flex-1 w-full flex flex-col justify-evenly">
-              <BarangayGreenery icon={Leaf} valueName="Greenery Index" value={selectedBarangay?.greeneryIndex ?? 0} />
-              <BarangayGreenery icon={Sprout} valueName="Normalized Difference Vegetation Index" value={selectedBarangay?.ndvi ?? 0} />
-              <BarangayGreenery icon={TreeDeciduous} valueName="Tree Canopy Cover" value={selectedBarangay?.treeCanopy ?? 0} />
-              <BarangayGreenery icon={Thermometer} valueName="Land Surface Temperature" value={selectedBarangay?.lst ?? 0} LST={true} />
+            <h4
+              className={`w-fit rounded-sm py-1 px-4 text-xl font-bold ${bgColor ?? ""} ${textColor ?? ""}`}
+            >
+              {selectedBarangay?.name ?? "Select a Barangay"}
+            </h4>
+            <hr className="w-full border-neutral-grey" />
+            <div className="flex w-full flex-1 flex-col justify-evenly gap-2">
+              <BarangayGreenery
+                icon={Leaf}
+                valueName="Greenery Index"
+                value={selectedBarangay?.greeneryIndex ?? 0}
+              />
+              <BarangayGreenery
+                icon={Sprout}
+                valueName="Normalized Difference Vegetation Index"
+                value={selectedBarangay?.ndvi ?? 0}
+              />
+              <BarangayGreenery
+                icon={TreeDeciduous}
+                valueName="Tree Canopy Cover"
+                value={selectedBarangay?.treeCanopy ?? 0}
+              />
+              <BarangayGreenery
+                icon={Thermometer}
+                valueName="Land Surface Temperature"
+                value={selectedBarangay?.lst ?? 0}
+                LST
+              />
             </div>
             <CollapsibleTrigger asChild>
-              <Button 
-                className="w-full flex justify-center items-center gap-1 py-2 bg-white border text-md font-medium rounded-md cursor-pointer hover:bg-gray-50 transition-colors"
-                style={{ 
-                  borderColor: textColor === 'text-green-600' ? '#16a34a' :
-                              textColor === 'text-lime-600' ? '#65a30d' :
-                              textColor === 'text-yellow-600' ? '#ca8a04' :
-                              textColor === 'text-red-600' ? '#dc2626' :
-                              textColor === 'text-gray-600' ? '#4b5563' : '#4b5563',
-                  color: textColor === 'text-green-600' ? '#16a34a' :
-                         textColor === 'text-lime-600' ? '#65a30d' :
-                         textColor === 'text-yellow-600' ? '#ca8a04' :
-                         textColor === 'text-red-600' ? '#dc2626' :
-                         textColor === 'text-gray-600' ? '#4b5563' : '#4b5563'
+              <Button
+                type="button"
+                className="flex w-full cursor-pointer items-center justify-center gap-1 rounded-md border bg-white py-2 text-md font-medium transition-colors hover:bg-gray-50"
+                style={{
+                  borderColor: effectiveTextColor,
+                  color: effectiveTextColor,
                 }}
                 disabled={!selectedBarangay}
               >
@@ -64,12 +105,12 @@ export default function CityGreeneryMap() {
                 {isOpen ? <ChevronsUp size={20} /> : <ChevronsDown size={20} />}
               </Button>
             </CollapsibleTrigger>
-          </div>
+          </aside>
         </div>
         <CollapsibleContent>
-            <BarangayGreeneryPage />
+          {/* TODO: replace with a dedicated detail component instead of importing a page-level route. */}
         </CollapsibleContent>
       </div>
     </Collapsible>
-  )
+  );
 }

--- a/src/components/ui/dashboard/indicatorcard.tsx
+++ b/src/components/ui/dashboard/indicatorcard.tsx
@@ -1,7 +1,9 @@
-import { Info } from "lucide-react";
-import HalfCircleBar from "./halfcirclebar";
-import { getTemperatureColor } from "@/lib/chloroplet-colors";
 import { useState } from "react";
+import { Info } from "lucide-react";
+
+import { getTemperatureColor } from "@/lib/chloroplet-colors";
+
+import HalfCircleBar from "./halfcirclebar";
 import IndicatorInfoModal from "./info_modals";
 
 interface IndicatorCardProps {
@@ -10,7 +12,10 @@ interface IndicatorCardProps {
   value: number;
   trendValue: number;
   description?: string;
-  LST?: boolean;
+  /**
+   * When true, renders the value as a temperature (°C) and uses temperature-based coloring.
+   */
+  isLST?: boolean;
 }
 
 export default function IndicatorCard({
@@ -19,55 +24,68 @@ export default function IndicatorCard({
   description,
   value,
   trendValue,
-  LST = false,
+  isLST = false,
 }: IndicatorCardProps) {
-  const classColor = LST ? getTemperatureColor(value) : "";
-  const [textColor, bgColor] = classColor.split(" ");
+  const temperatureClassColor = isLST ? getTemperatureColor(value) : "";
+  const [textColor] = temperatureClassColor.split(" ");
 
-  const [openModal, setOpenModal] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const trendLabel = trendValue >= 0 ? `+${trendValue}` : `${trendValue}`;
 
   return (
     <>
-      <div className="border flex-1 w-full bg-white shadow-md rounded-lg p-4 flex flex-col items-center justify-center gap-6">
-        <div className="flex flex-row justify-between items-start w-full">
+      <div className="flex w-full flex-1 flex-col items-center justify-center gap-6 rounded-lg border bg-white p-4 shadow-md">
+        <div className="flex w-full items-start justify-between">
           <div className="flex flex-col text-left">
-            <h2 className="text-neutral-black text-md font-semibold whitespace-nowrap">
+            <h2 className="whitespace-nowrap text-md font-semibold text-neutral-black">
               {title}
             </h2>
-            <p className="text-neutral-black/50">{subtitle}</p>
+            <p className="text-sm text-neutral-black/60">{subtitle}</p>
           </div>
 
           <button
-            onClick={() => setOpenModal(true)}
-            className="text-neutral-black/40 hover:text-neutral-black/80 p-1 rounded-full transition-all duration-150 cursor-pointer -mt-1 -mr-1"
+            type="button"
+            onClick={handleOpenModal}
+            className="relative -mt-1 -mr-1 rounded-full p-1 text-neutral-black/40 transition-colors hover:text-neutral-black/80"
+            aria-label={`More information about ${title}`}
           >
-            <Info />
+            <Info className="h-4 w-4" aria-hidden />
           </button>
         </div>
 
-        {LST ? (
+        {isLST ? (
           <>
             <p
-              className={`h-full w-full text-center text-5xl font-bold ${textColor}`}
+              className={`h-full w-full text-center text-4xl font-bold sm:text-5xl ${textColor ?? ""}`}
             >
               {value}°C
             </p>
-            <p className={`${textColor} w-full text-right`}>+{trendValue}°C</p>
+            <p className={`${textColor ?? ""} w-full text-right text-sm`}>
+              {trendLabel}°C
+            </p>
           </>
         ) : (
           <>
             <HalfCircleBar value={value} />
-            <p className="text-primary-green w-full text-right">
-              +{trendValue}
+            <p className="w-full text-right text-sm text-primary-green">
+              {trendLabel}
             </p>
           </>
         )}
       </div>
 
-      {/* Popup Modal */}
       <IndicatorInfoModal
-        open={openModal}
-        onClose={() => setOpenModal(false)}
+        open={isModalOpen}
+        onClose={handleCloseModal}
         title={title}
         description={description ?? ""}
       />


### PR DESCRIPTION
### Summary

Refactor and clean up the dashboard experience across `home_dashboard`, `explore`, and shared dashboard components for better structure, responsiveness, and maintainability, without changing user‑visible behavior.

### What changed

#### Dashboard page (`src/app/home_dashboard/page.tsx`)

- Extracted a `useMetricDescriptions` hook that:
  - Fetches metric descriptions once on mount via `fetchMetricDescriptions`.
  - Guards against state updates after unmount using an `isMounted` flag.
  - Exposes a memoized `getDescription(name)` helper that prefers `what`/`why` fields and falls back to `description`.
- Restructured layout and semantics:
  - More responsive, mobile‑first container with consistent padding and spacing.
  - Clear separation between header and content sections, with better wrapping on small screens.
  - Converted the metrics row to a responsive grid (`md:grid-cols-2`, `lg:grid-cols-4`) instead of a rigid flex row.
- Cleaned imports and typing:
  - Grouped imports logically and used `type MetricDescriptions` for typing.
  - Used `useMemo` for both the current date label and the description lookup helper.

#### Indicator card (`src/components/ui/dashboard/indicatorcard.tsx`)

- Renamed boolean prop `LST` → `isLST` for clearer semantics and consistency with React naming conventions.
- Simplified internal state and handlers:
  - Introduced `isModalOpen`, `handleOpenModal`, and `handleCloseModal` for better readability.
  - Normalized trend formatting via a `trendLabel` helper that always prefixes positive values with `"+"`.
- Improved styling and accessibility:
  - Tightened Tailwind classes for spacing and typography.
  - Added an `aria-label` to the info button for better screen‑reader support.
- Kept the external behavior and integration with `IndicatorInfoModal` unchanged aside from the prop rename.

#### City greenery map (`src/components/ui/dashboard/CityGreeneryMap.tsx`)

- Removed cross‑layer coupling:
  - Dropped the direct import of the `barangays_greenery/[id]/page` route; left a `TODO` comment pointing to a future dedicated detail component instead.
- Reorganized imports and layout:
  - Grouped icon, context, UI, and local component imports for easier scanning.
  - Updated the container so it stacks vertically on mobile and uses a side‑by‑side layout (`md:flex-row`) on larger screens.
- Centralized greenery color logic:
  - Derived `greeneryClassColor` from `getGreeneryClassColor` and computed a single `effectiveTextColor` hex value used for the “View More Details” button border and text.
  - Continued using the Tailwind `bgColor`/`textColor` pair for the barangay label, preserving the existing visual language.

#### Explore page (`src/app/explore/page.tsx`)

- Import and typing cleanup:
  - Reordered imports into hooks → framework → libraries → components → types.
  - Switched to `type` imports for `BarangayData`, `SelectedFeature`, `GreenRecommendation`, and `SidebarView`.
- Map loader and geo data handling:
  - Updated the `MapWrapper` loading UI to match the rest of the app (rounded, dashed border, centered spinner and label).
  - Typed `/geo/mandaue_barangays_gi.geojson` as `GeoJSON.FeatureCollection` and explicitly cast feature properties.
  - Added a `.catch` branch that logs a clear error if geo data fails to load without crashing the page.
- Local metrics dashboard:
  - Renamed the local `MetricsDashboard` component to `ExploreMetricsDashboard` to avoid confusion with shared components.
  - Updated metric labels to align with the rest of the dashboard (`Greenery Index`, `Tree Canopy`, `Surface Temp`) and normalized Tailwind classes.
- Minor clarity improvements:
  - Clarified the `handleFeatureSelected` callback signature to accept a `SelectedFeature`.
  - Kept EXIF/selection behavior unchanged while improving logging and code readability.

### Rationale

- **Maintainability**: Extracted hooks and clearer prop naming make the dashboard logic easier to understand, reuse, and test.
- **Consistency**: Aligns metric naming, layout patterns, and Tailwind usage across the dashboard and explore surfaces.
- **Robustness & UX**: Adds basic guards for async flows and data loading while improving responsiveness, without altering the underlying behavior.

### Test plan

- **Dashboard (`/home_dashboard`)**
  - Load the page and confirm:
    - Header still shows “Mandaue City” and the current date label.
    - All four indicator cards display the same values as before, with LST still styled and suffixed with `°C`.
    - Clicking each info icon opens a modal populated from `terms/termdefs.json` and the modal closes via overlay click or close button.
  - Resize between mobile, tablet, and desktop:
    - On small screens, indicators stack into 1–2 columns.
    - On large screens, indicators render as 4 columns without overflow or layout breaks.
  - Check the browser console for absence of new errors or warnings related to metric descriptions.

- **CityGreeneryMap**
  - On `/home_dashboard`, verify:
    - The map renders correctly and the sidebar shows the selected barangay’s four metrics.
    - “View More Details” is disabled when no barangay is selected and enabled when one is.
    - The button color reflects the greenery class (green / lime / yellow / red / gray).
  - Resize the viewport:
    - Mobile: map and sidebar stack vertically.
    - Desktop: map and sidebar appear side‑by‑side with correct borders and spacing.

- **Explore (`/explore`)**
  - Initial load:
    - Confirm the updated map loader appears, then transitions to the interactive map without errors.
  - Barangay selection:
    - Select a barangay via the map or search and confirm `ExploreMetricsDashboard` appears with updated labels and metric values.
  - Photo upload:
    - Upload a geotagged photo and verify marker placement, fly‑to behavior, and sidebar/bottom sheet opening still work as before.
  - GeoJSON failure handling:
    - (Optional) Temporarily break `/geo/mandaue_barangays_gi.geojson` and confirm a clear console error is logged while the UI does not crash.
  - Ensure there are no new TypeScript or lint errors.

