### PR TITLE
Add shared cost estimation model

### DIFF
--- a/src/app/api/cost-estimate/route.ts
+++ b/src/app/api/cost-estimate/route.ts
@@ -1,17 +1,47 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
+import {
+  estimateInterventionCost,
+  type CostEstimationScope,
+} from "@/lib/cost-estimation";
+
+function parseNumber(value: string | null): number | null {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseScope(value: string | null): CostEstimationScope | null {
+  if (value === "project" || value === "site" || value === "barangay") {
+    return value;
+  }
+  return null;
+}
 
 /**
- * GET /api/cost-estimate - Calculate cost estimate for a greening intervention
+ * GET /api/cost-estimate - Calculate cost estimate for a greening intervention.
  * Query parameters:
- *   - interventionType: Type of intervention (e.g., "Urban canopy enhancement", "Rain garden installation")
- *   - area: Area in square meters (optional)
- *   - barangayId: Barangay ID for location-based pricing (optional)
+ *   - interventionType: required, any supported or aliased intervention label
+ *   - solutionTitle: optional human-readable recommendation title
+ *   - solutionDescription: optional short description used for model inference
+ *   - area: optional site area in square meters
+ *   - scope: optional project/site/barangay scope hint
+ *   - greeneryIndex: optional 0-1 site greenness signal
+ *   - floodHazard: optional 0-3 hazard level
+ *   - stormHazard: optional 0-3 hazard level
+ *   - lifecycleYears: optional planning horizon
  */
 export async function GET(request: NextRequest) {
   try {
     const interventionType = request.nextUrl.searchParams.get('interventionType');
-    const area = request.nextUrl.searchParams.get('area');
+    const solutionTitle = request.nextUrl.searchParams.get('solutionTitle');
+    const solutionDescription = request.nextUrl.searchParams.get('solutionDescription');
+    const area = parseNumber(request.nextUrl.searchParams.get('area'));
     const barangayId = request.nextUrl.searchParams.get('barangayId');
+    const scope = parseScope(request.nextUrl.searchParams.get('scope'));
+    const greeneryIndex = parseNumber(request.nextUrl.searchParams.get('greeneryIndex'));
+    const floodHazard = parseNumber(request.nextUrl.searchParams.get('floodHazard'));
+    const stormHazard = parseNumber(request.nextUrl.searchParams.get('stormHazard'));
+    const lifecycleYears = parseNumber(request.nextUrl.searchParams.get('lifecycleYears'));
 
     if (!interventionType) {
       return NextResponse.json(
@@ -20,91 +50,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Cost estimation based on intervention type
-    const costEstimates: Record<string, { basePrice: number; unit: string; perUnit: string }> = {
-      'urban canopy enhancement': {
-        basePrice: 5000,
-        unit: 'PHP',
-        perUnit: 'per tree'
-      },
-      'rain garden installation': {
-        basePrice: 15000,
-        unit: 'PHP',
-        perUnit: 'per installation'
-      },
-      'green corridor development': {
-        basePrice: 50000,
-        unit: 'PHP',
-        perUnit: 'per 100m corridor'
-      },
-      'rooftop garden installation': {
-        basePrice: 3000,
-        unit: 'PHP',
-        perUnit: 'per square meter'
-      },
-      'permeable pavement': {
-        basePrice: 2500,
-        unit: 'PHP',
-        perUnit: 'per square meter'
-      },
-      'green wall installation': {
-        basePrice: 8000,
-        unit: 'PHP',
-        perUnit: 'per square meter'
-      },
-      'wetland restoration': {
-        basePrice: 20000,
-        unit: 'PHP',
-        perUnit: 'per hectare'
-      },
-    };
-
-    // Get base estimate
-    const interventionKey = interventionType.toLowerCase();
-    const estimate = costEstimates[interventionKey] || {
-      basePrice: 10000,
-      unit: 'PHP',
-      perUnit: 'per project'
-    };
-
-    // Calculate total cost if area is provided
-    let totalCost = estimate.basePrice;
-    if (area) {
-      const areaValue = parseFloat(area);
-      if (!isNaN(areaValue)) {
-        totalCost = estimate.basePrice * areaValue;
-      }
-    }
-
-    // Location-based multiplier (could be enhanced with actual barangay data)
-    let locationMultiplier = 1;
-    if (barangayId) {
-      // Example multipliers - could be fetched from database
-      const locationMultipliers: Record<string, number> = {
-        'barangay1': 0.9, // 10% cheaper in some areas
-        'barangay2': 1.1, // 10% more expensive in others
-      };
-      locationMultiplier = locationMultipliers[barangayId] || 1;
-    }
-
-    totalCost = totalCost * locationMultiplier;
+    const estimate = estimateInterventionCost({
+      interventionType,
+      solutionTitle,
+      solutionDescription,
+      areaSqm: area,
+      barangayId,
+      scope,
+      greeneryIndex,
+      floodHazard,
+      stormHazard,
+      lifecycleYears,
+    });
 
     return NextResponse.json({
       success: true,
-      data: {
-        interventionType,
-        basePrice: estimate.basePrice,
-        totalEstimate: Math.round(totalCost),
-        currencyUnit: estimate.unit,
-        perUnit: estimate.perUnit,
-        area: area ? parseFloat(area) : null,
-        locationMultiplier,
-        breakdown: {
-          materials: Math.round(totalCost * 0.5),
-          labor: Math.round(totalCost * 0.35),
-          contingency: Math.round(totalCost * 0.15),
-        }
-      }
+      data: estimate,
     });
   } catch (error: any) {
     console.error('Error calculating cost estimate:', error);
@@ -123,8 +84,15 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const {
       interventionType,
+      solutionTitle,
+      solutionDescription,
       area,
       barangayId,
+      scope,
+      greeneryIndex,
+      floodHazard,
+      stormHazard,
+      lifecycleYears,
       customization,
     } = body;
 
@@ -135,24 +103,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Use GET logic to calculate base estimate
-    const params = new URLSearchParams({
-      interventionType,
-      ...(area && { area: area.toString() }),
-      ...(barangayId && { barangayId }),
-    });
-
-    const getRequest = new NextRequest(
-      `${request.nextUrl.origin}/api/cost-estimate?${params}`,
-      { method: 'GET' }
-    );
-
-    const response = await GET(getRequest);
-    const result = await response.json();
-
-    if (!result.success) {
-      return response;
-    }
+    const result = {
+      success: true,
+      data: estimateInterventionCost({
+        interventionType,
+        solutionTitle: typeof solutionTitle === "string" ? solutionTitle : null,
+        solutionDescription: typeof solutionDescription === "string" ? solutionDescription : null,
+        areaSqm: typeof area === "number" ? area : parseNumber(area?.toString() ?? null),
+        barangayId,
+        scope: parseScope(typeof scope === "string" ? scope : null),
+        greeneryIndex: typeof greeneryIndex === "number" ? greeneryIndex : parseNumber(greeneryIndex?.toString() ?? null),
+        floodHazard: typeof floodHazard === "number" ? floodHazard : parseNumber(floodHazard?.toString() ?? null),
+        stormHazard: typeof stormHazard === "number" ? stormHazard : parseNumber(stormHazard?.toString() ?? null),
+        lifecycleYears: typeof lifecycleYears === "number" ? lifecycleYears : parseNumber(lifecycleYears?.toString() ?? null),
+      }),
+    };
 
     // Apply customization multiplier if provided
     if (customization?.additionalServices) {
@@ -161,6 +126,8 @@ export async function POST(request: NextRequest) {
         0
       );
       result.data.totalEstimate += additionalCost;
+      result.data.breakdown.contingency += additionalCost;
+      result.data.assumptions.push("Additional services were added on top of the base lifecycle estimate.");
     }
 
     return NextResponse.json(result);

--- a/src/app/api/greenery-index/route.ts
+++ b/src/app/api/greenery-index/route.ts
@@ -9,6 +9,11 @@ import { computeBarangayCentroids } from "@/lib/geo/centroids";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+type BarangayMetricRow = {
+  name: string;
+  area_km2?: number | null;
+};
+
 export async function GET() {
   try {
     const boundsPath = path.join(
@@ -17,6 +22,16 @@ export async function GET() {
     );
     const boundsRaw = await fs.readFile(boundsPath, "utf8");
     const bounds = JSON.parse(boundsRaw) as GeoJSON.FeatureCollection;
+
+    const metricsPath = path.join(
+      process.cwd(),
+      "public/metrics/mandaue_metrics.json",
+    );
+    const metricsRaw = await fs.readFile(metricsPath, "utf8");
+    const barangayMetrics = JSON.parse(metricsRaw) as BarangayMetricRow[];
+    const areaLookup = new Map(
+      barangayMetrics.map((row) => [row.name.toLowerCase(), row.area_km2 ?? null]),
+    );
 
     const centroids = computeBarangayCentroids(bounds);
     const geeData = await fetchGeeMetricsBulk(centroids);
@@ -30,14 +45,15 @@ export async function GET() {
       const greenArea = estimateGreenArea(ndvi, 1);
 
       const gi = calculateGreeneryIndex({ ndvi, lst, treeCanopy, greenArea });
-      giLookup.set(name, gi);
+      giLookup.set(name.toLowerCase(), gi);
     }
 
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 
     const features: GeoJSON.Feature[] = bounds.features.map((f) => {
       const name = f.properties?.name;
-      const gi = name ? giLookup.get(name) : undefined;
+      const normalizedName = typeof name === "string" ? name.toLowerCase() : null;
+      const gi = normalizedName ? giLookup.get(normalizedName) : undefined;
 
       return {
         type: "Feature",
@@ -50,6 +66,7 @@ export async function GET() {
           ndvi: gi?.metrics.ndvi ?? null,
           lst: gi?.metrics.lst ?? null,
           treeCanopy: gi?.metrics.treeCanopy ?? null,
+          area_km2: normalizedName ? areaLookup.get(normalizedName) ?? null : null,
           date: today,
         },
       };

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -271,6 +271,7 @@ export default function ExplorePage() {
               lst: (item.properties?.lst as number | undefined) ?? 0,
               treeCanopy:
                 (item.properties?.treeCanopy as number | undefined) ?? 0,
+              area_km2: (item.properties?.area_km2 as number | undefined) ?? undefined,
               floodExposure: "",
               currentIntervention: "",
             };

--- a/src/components/ui/dashboard/InterventionAnalysisTable.tsx
+++ b/src/components/ui/dashboard/InterventionAnalysisTable.tsx
@@ -1,14 +1,38 @@
 "use client";
 
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Download, Filter, ArrowUpDown, SlidersHorizontal } from 'lucide-react';
 import { getGreeneryTextColor } from '@/lib/chloroplet-colors';
 import SimulationModal from '../simulation/Simulation';
+import { estimateInterventionCost } from '@/lib/cost-estimation';
 
 import { useBarangay } from '@/context/BarangayContext';
 import { useGeoData } from '@/context/geoDataStore';
 // Sample data - expanded dataset
 // Data is now fetched dynamically from useGeoData context
+
+type MetricsRow = {
+  name: string;
+  area_km2: number;
+};
+
+function normalizeFloodExposure(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'high') return 3;
+  if (normalized === 'medium') return 2;
+  if (normalized === 'low') return 1;
+  return null;
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-PH', {
+    style: 'currency',
+    currency: 'PHP',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
 
 export default function InterventionAnalysisTable() {
   const [equityRange, setEquityRange] = useState([0, 1]);
@@ -16,9 +40,31 @@ export default function InterventionAnalysisTable() {
   const [sortColumn, setSortColumn] = useState('equity');
   const [sortDirection, setSortDirection] = useState('desc');
   const [isSimulationOpen, setIsSimulationOpen] = useState(false);
+  const [metricsByName, setMetricsByName] = useState<Record<string, number>>({});
 
   const { setSimulationBarangay } = useBarangay();
   const geoData = useGeoData((state) => state.geoData);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch('/metrics/mandaue_metrics.json')
+      .then((response) => response.json())
+      .then((rows: MetricsRow[]) => {
+        if (cancelled) return;
+        const lookup = Object.fromEntries(
+          rows.map((row) => [row.name.toLowerCase(), row.area_km2]),
+        );
+        setMetricsByName(lookup);
+      })
+      .catch((error) => {
+        console.error('Failed to load barangay metrics for cost estimates:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   function selectByName(name: string) {
     if (!geoData) return;
@@ -34,6 +80,7 @@ export default function InterventionAnalysisTable() {
       ndvi: feature.properties?.ndvi ?? 0,
       lst: feature.properties?.lst ?? 0,
       treeCanopy: feature.properties?.tree_canopy ?? 0,
+      area_km2: metricsByName[(feature.properties?.name ?? name).toLowerCase()],
       floodExposure: feature.properties?.flood_exposure ?? "unknown",
       currentIntervention: feature.properties?.current_intervention ?? "None",
     });
@@ -41,25 +88,52 @@ export default function InterventionAnalysisTable() {
   // Transform GeoJSON features into table rows
   const tableData = useMemo(() => {
     if (!geoData) return [];
-    return geoData.features.map((f: any, idx: number) => {
+    const rawRows = geoData.features.map((f: any, idx: number) => {
       const p = f.properties;
       const equity = p.greenery_index ?? 0.5;
       const impact = (p.ndvi ?? 0.5) * (p.tree_canopy ?? 0.5);
-      // Realistic cost estimation based on area and current GI
-      const cost = 1 - (equity * 0.4 + (p.area_km2 ?? 1) * 0.2); 
+      const barangayName = String(p.name || `Barangay ${idx}`);
+      const recommendedIntervention = p.current_intervention || 'Urban canopy enhancement';
+      const areaKm2 = metricsByName[barangayName.toLowerCase()] ?? null;
+      const areaSqm = areaKm2 !== null ? areaKm2 * 1_000_000 : null;
+      const estimatedCost = estimateInterventionCost({
+        interventionType: recommendedIntervention,
+        solutionTitle: recommendedIntervention,
+        areaSqm,
+        barangayId: barangayName,
+        scope: 'barangay',
+        greeneryIndex: equity,
+        floodHazard: normalizeFloodExposure(p.flood_exposure),
+      });
       
       return {
         id: idx,
-        barangay: p.name || `Barangay ${idx}`,
+        barangay: barangayName,
         equity,
-        cost,
+        estimatedCostPhp: estimatedCost.totalEstimate,
         impact,
         status: equity > 0.8 ? 'Excellent' : equity > 0.6 ? 'Good' : equity > 0.4 ? 'Fair' : 'Poor',
-        recommendedIntervention: p.current_intervention || 'Urban canopy enhancement',
+        recommendedIntervention,
         source: 'ESA / NASA / NOAH'
       };
     });
-  }, [geoData]);
+
+    const costs = rawRows.map((row) => row.estimatedCostPhp);
+    const minCost = Math.min(...costs);
+    const maxCost = Math.max(...costs);
+
+    return rawRows.map((row) => {
+      const cost =
+        maxCost === minCost
+          ? 0.5
+          : 1 - ((row.estimatedCostPhp - minCost) / (maxCost - minCost));
+
+      return {
+        ...row,
+        cost,
+      };
+    });
+  }, [geoData, metricsByName]);
 
   // Filter and sort data based on slider ranges
   const filteredData = useMemo(() => {
@@ -189,6 +263,9 @@ export default function InterventionAnalysisTable() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className={`text-sm font-semibold ${getGreeneryTextColor(row.cost)}`}>{row.cost.toFixed(2)}</div>
+                      <div className="text-[10px] text-gray-500 mt-0.5">
+                        {formatCurrency(row.estimatedCostPhp)}
+                      </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-neutral-black">
                       {row.impact.toFixed(2)}

--- a/src/components/ui/green_solutions/SidebarDetails/CostEstimateCard.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/CostEstimateCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DollarSign, Package, Wrench, AlertCircle } from 'lucide-react';
+import { DollarSign, Package, Wrench, AlertCircle, Clock3 } from 'lucide-react';
 import type { CostEstimate } from '@/types/green_solutions';
 
 interface CostEstimateCardProps {
@@ -33,6 +33,8 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
     }).format(amount);
   };
 
+  const totalEstimate = Math.max(costEstimate.totalEstimate, 1);
+
   return (
     <div className="space-y-4">
       {/* Main cost card */}
@@ -51,8 +53,18 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
             {formatCurrency(costEstimate.totalEstimate)}
           </p>
           <p className="text-xs text-neutral-600">
-            {costEstimate.perUnit} {costEstimate.area ? `• ${costEstimate.area.toFixed(2)} m²` : ''}
+            {costEstimate.perUnit}
+            {costEstimate.quantity && costEstimate.quantity > 1
+              ? ` • ${costEstimate.quantity.toFixed(0)} units`
+              : ''}
+            {costEstimate.area ? ` • ${costEstimate.area.toFixed(2)} m²` : ''}
           </p>
+          {costEstimate.lifecycleYears ? (
+            <p className="text-xs text-neutral-500 flex items-center gap-1.5">
+              <Clock3 size={12} />
+              Lifecycle horizon: {costEstimate.lifecycleYears} years
+            </p>
+          ) : null}
           {costEstimate.locationMultiplier !== 1 && (
             <p className="text-xs text-neutral-500">
               Location adjustment: {((costEstimate.locationMultiplier - 1) * 100).toFixed(0)}%
@@ -77,7 +89,7 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
               <div>
                 <p className="text-sm font-semibold text-neutral-900">Materials</p>
                 <p className="text-xs text-neutral-500">
-                  {((costEstimate.breakdown.materials / costEstimate.totalEstimate) * 100).toFixed(0)}%
+                  {((costEstimate.breakdown.materials / totalEstimate) * 100).toFixed(0)}%
                 </p>
               </div>
             </div>
@@ -95,7 +107,7 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
               <div>
                 <p className="text-sm font-semibold text-neutral-900">Labor</p>
                 <p className="text-xs text-neutral-500">
-                  {((costEstimate.breakdown.labor / costEstimate.totalEstimate) * 100).toFixed(0)}%
+                  {((costEstimate.breakdown.labor / totalEstimate) * 100).toFixed(0)}%
                 </p>
               </div>
             </div>
@@ -113,7 +125,7 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
               <div>
                 <p className="text-sm font-semibold text-neutral-900">Contingency</p>
                 <p className="text-xs text-neutral-500">
-                  {((costEstimate.breakdown.contingency / costEstimate.totalEstimate) * 100).toFixed(0)}%
+                  {((costEstimate.breakdown.contingency / totalEstimate) * 100).toFixed(0)}%
                 </p>
               </div>
             </div>
@@ -121,12 +133,31 @@ export default function CostEstimateCard({ costEstimate, isLoading = false }: Co
               {formatCurrency(costEstimate.breakdown.contingency)}
             </p>
           </div>
+
+          {typeof costEstimate.breakdown.maintenance === 'number' && (
+            <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-neutral-100">
+              <div className="flex items-center gap-2">
+                <div className="w-7 h-7 bg-emerald-50 rounded flex items-center justify-center">
+                  <Clock3 size={16} className="text-emerald-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-neutral-900">Lifecycle Maintenance</p>
+                  <p className="text-xs text-neutral-500">
+                    {((costEstimate.breakdown.maintenance / totalEstimate) * 100).toFixed(0)}%
+                  </p>
+                </div>
+              </div>
+              <p className="font-bold text-neutral-900">
+                {formatCurrency(costEstimate.breakdown.maintenance)}
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Cost info */}
         <div className="pt-2 border-t border-neutral-200">
           <p className="text-xs text-neutral-500">
-            Base cost: {formatCurrency(costEstimate.basePrice)} • Estimate may vary based on site conditions
+            Reference unit cost: {formatCurrency(costEstimate.basePrice)} • Estimate may vary based on site conditions
           </p>
         </div>
       </div>

--- a/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
@@ -10,6 +10,81 @@ import HalfCircleBar from "@/components/ui/dashboard/halfcirclebar";
 import GreenSolutionCard from "../../general/cards/greensolution-infocard";
 import CostEstimateCard from "./CostEstimateCard";
 
+type HazardEntry = {
+  level: number | null;
+};
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function maxHazardLevel(entries?: HazardEntry[] | null): number | null {
+  const levels = (entries ?? [])
+    .map((entry) => entry.level)
+    .filter((level): level is number => typeof level === "number" && Number.isFinite(level));
+  if (levels.length === 0) {
+    return null;
+  }
+  return Math.max(...levels);
+}
+
+function resolveAreaSqm(
+  selectedFeature: SelectedFeature,
+  selectedBarangayData: BarangayData | null,
+): number | null {
+  const properties = selectedFeature.properties as Record<string, unknown> | undefined;
+  const directAreaSqm =
+    toFiniteNumber(properties?.area_sqm) ??
+    toFiniteNumber(properties?.areaSqm) ??
+    toFiniteNumber(properties?.area_m2) ??
+    toFiniteNumber(properties?.areaM2);
+  if (directAreaSqm !== null && directAreaSqm > 0) {
+    return directAreaSqm;
+  }
+
+  const directAreaKm2 =
+    toFiniteNumber(properties?.area_km2) ??
+    toFiniteNumber(properties?.areaKm2);
+  if (directAreaKm2 !== null && directAreaKm2 > 0) {
+    return directAreaKm2 * 1_000_000;
+  }
+
+  const isBarangayCoverage =
+    selectedFeature.address === "Barangay Coverage" ||
+    (selectedFeature.coords.lng === 0 && selectedFeature.coords.lat === 0);
+
+  if (isBarangayCoverage) {
+    const barangayAreaKm2 = selectedBarangayData?.area_km2 ?? null;
+    if (barangayAreaKm2 !== null && barangayAreaKm2 > 0) {
+      return barangayAreaKm2 * 1_000_000;
+    }
+  }
+
+  return null;
+}
+
+function resolveScope(
+  selectedFeature: SelectedFeature,
+  areaSqm: number | null,
+): "project" | "site" | "barangay" {
+  const isBarangayCoverage =
+    selectedFeature.address === "Barangay Coverage" ||
+    (selectedFeature.coords.lng === 0 && selectedFeature.coords.lat === 0);
+
+  if (isBarangayCoverage) {
+    return "barangay";
+  }
+
+  return areaSqm !== null ? "site" : "project";
+}
+
 interface InfoTabProps {
   recommendation: UIRecommendation;
   selectedFeature: SelectedFeature;
@@ -36,10 +111,52 @@ export default function InfoTab({
 
     // Fetch cost estimate from API
     const fetchCostEstimate = async () => {
+      const interventionType = recommendation.interventionType || recommendation.solutionTitle;
+      const solutionTitle = recommendation.solutionTitle;
+      const solutionDescription = recommendation.detailedDescription || recommendation.solutionDescription;
+      const areaSqm = resolveAreaSqm(selectedFeature, selectedBarangayData);
+      const scope = resolveScope(selectedFeature, areaSqm);
+      const greeneryIndex =
+        toFiniteNumber(selectedFeature.properties?.greeneryIndex) ??
+        toFiniteNumber(selectedFeature.properties?.greenery_index) ??
+        selectedBarangayData?.greeneryIndex ??
+        null;
+      const floodHazard = maxHazardLevel(selectedFeature.hazards?.flood);
+      const stormHazard = maxHazardLevel(selectedFeature.hazards?.storm);
+      const barangayId = selectedFeature.barangay || selectedBarangayData?.name || null;
+
       try {
-        const params = new URLSearchParams({
-          interventionType: recommendation.solutionTitle,
-        });
+        const params = new URLSearchParams();
+        params.set("interventionType", interventionType);
+        params.set("scope", scope);
+
+        if (solutionTitle) {
+          params.set("solutionTitle", solutionTitle);
+        }
+
+        if (solutionDescription) {
+          params.set("solutionDescription", solutionDescription);
+        }
+
+        if (areaSqm !== null) {
+          params.set("area", areaSqm.toString());
+        }
+
+        if (barangayId) {
+          params.set("barangayId", barangayId);
+        }
+
+        if (greeneryIndex !== null) {
+          params.set("greeneryIndex", greeneryIndex.toString());
+        }
+
+        if (floodHazard !== null) {
+          params.set("floodHazard", floodHazard.toString());
+        }
+
+        if (stormHazard !== null) {
+          params.set("stormHazard", stormHazard.toString());
+        }
 
         const response = await fetch(`/api/cost-estimate?${params}`);
         const result = await response.json();
@@ -54,8 +171,10 @@ export default function InfoTab({
       }
     };
 
+    setCostEstimate(null);
+    setIsLoadingCost(true);
     fetchCostEstimate();
-  }, [recommendation]);
+  }, [recommendation, selectedBarangayData, selectedFeature]);
 
   return (
     <div className="sm:px-2 lg:px-6 h-full overflow-y-auto space-y-6 scrollbar-hide">

--- a/src/context/BarangayContext.tsx
+++ b/src/context/BarangayContext.tsx
@@ -8,6 +8,7 @@ export interface BarangayData {
   ndvi: number;
   lst: number;
   treeCanopy: number;
+  area_km2?: number;
   /** Band from composite GI (e.g. Very Low … Very High) when available */
   greeneryLevel?: string;
   /** Live AQI when available (e.g. WAQI at point) */

--- a/src/lib/cost-estimation.ts
+++ b/src/lib/cost-estimation.ts
@@ -1,0 +1,476 @@
+export type CostEstimationScope = "project" | "site" | "barangay";
+
+export interface CostEstimateBreakdown {
+  materials: number;
+  labor: number;
+  contingency: number;
+  maintenance?: number;
+}
+
+export interface CostEstimateInput {
+  interventionType: string;
+  solutionTitle?: string | null;
+  solutionDescription?: string | null;
+  areaSqm?: number | null;
+  barangayId?: string | null;
+  scope?: CostEstimationScope | null;
+  greeneryIndex?: number | null;
+  floodHazard?: number | null;
+  stormHazard?: number | null;
+  lifecycleYears?: number | null;
+  locationMultiplier?: number | null;
+}
+
+export interface CostEstimateResult {
+  interventionType: string;
+  basePrice: number;
+  totalEstimate: number;
+  currencyUnit: string;
+  perUnit: string;
+  area: number | null;
+  locationMultiplier: number;
+  quantity: number;
+  lifecycleYears: number;
+  scope: CostEstimationScope;
+  breakdown: CostEstimateBreakdown;
+  assumptions: string[];
+}
+
+type AreaMode = "none" | "exact" | "ceil";
+
+type InterventionModel = {
+  key: string;
+  aliases: string[];
+  perUnit: string;
+  basePrice: number;
+  areaMode: AreaMode;
+  referenceAreaSqm: number;
+  scaleWithBarangayArea: boolean;
+  lifecycleYears: number;
+  materialsShare: number;
+  laborShare: number;
+  maintenanceRate: number;
+  notes: string[];
+};
+
+const INTERVENTION_MODELS: InterventionModel[] = [
+  {
+    key: "urban canopy enhancement",
+    aliases: [
+      "urban canopy enhancement",
+      "urban canopy",
+      "street trees",
+      "street tree planting",
+      "canopy",
+      "tree planting",
+    ],
+    perUnit: "per tree",
+    basePrice: 5200,
+    areaMode: "ceil",
+    referenceAreaSqm: 25,
+    scaleWithBarangayArea: true,
+    lifecycleYears: 5,
+    materialsShare: 0.52,
+    laborShare: 0.33,
+    maintenanceRate: 0.08,
+    notes: [
+      "Area is translated into a planting density of roughly 1 tree per 25 m² when a site footprint is available.",
+      "Includes an establishment allowance over the selected lifecycle horizon.",
+    ],
+  },
+  {
+    key: "rain garden installation",
+    aliases: [
+      "rain garden installation",
+      "rain garden",
+      "bioswale",
+      "stormwater garden",
+    ],
+    perUnit: "per installation",
+    basePrice: 18000,
+    areaMode: "ceil",
+    referenceAreaSqm: 50,
+    scaleWithBarangayArea: true,
+    lifecycleYears: 5,
+    materialsShare: 0.5,
+    laborShare: 0.34,
+    maintenanceRate: 0.06,
+    notes: [
+      "A 50 m² catchment footprint is used as a planning proxy when area is available.",
+    ],
+  },
+  {
+    key: "green corridor development",
+    aliases: [
+      "green corridor development",
+      "green corridor",
+      "blue-green corridors",
+      "blue green corridors",
+      "corridor",
+    ],
+    perUnit: "per 100m corridor",
+    basePrice: 65000,
+    areaMode: "ceil",
+    referenceAreaSqm: 300,
+    scaleWithBarangayArea: true,
+    lifecycleYears: 5,
+    materialsShare: 0.55,
+    laborShare: 0.3,
+    maintenanceRate: 0.05,
+    notes: [
+      "Area is converted to an estimated 100 m corridor segment using a 3 m right-of-way proxy.",
+    ],
+  },
+  {
+    key: "rooftop garden installation",
+    aliases: [
+      "rooftop garden installation",
+      "rooftop garden",
+      "roof gardens",
+      "roof garden",
+      "building envelope green",
+    ],
+    perUnit: "per square meter",
+    basePrice: 3500,
+    areaMode: "exact",
+    referenceAreaSqm: 1,
+    scaleWithBarangayArea: false,
+    lifecycleYears: 7,
+    materialsShare: 0.58,
+    laborShare: 0.32,
+    maintenanceRate: 0.07,
+    notes: [
+      "Area is used directly only when a site footprint is explicitly provided.",
+    ],
+  },
+  {
+    key: "permeable pavement",
+    aliases: ["permeable pavement", "permeable paving", "porous pavement"],
+    perUnit: "per square meter",
+    basePrice: 2800,
+    areaMode: "exact",
+    referenceAreaSqm: 1,
+    scaleWithBarangayArea: false,
+    lifecycleYears: 8,
+    materialsShare: 0.6,
+    laborShare: 0.28,
+    maintenanceRate: 0.04,
+    notes: [
+      "Area is used directly only when the selected site footprint is explicit.",
+    ],
+  },
+  {
+    key: "green wall installation",
+    aliases: ["green wall installation", "green wall", "living wall"],
+    perUnit: "per square meter",
+    basePrice: 9000,
+    areaMode: "exact",
+    referenceAreaSqm: 1,
+    scaleWithBarangayArea: false,
+    lifecycleYears: 7,
+    materialsShare: 0.56,
+    laborShare: 0.32,
+    maintenanceRate: 0.08,
+    notes: [
+      "Area is used directly only when a facade or wall surface is explicitly provided.",
+    ],
+  },
+  {
+    key: "wetland restoration",
+    aliases: ["wetland restoration", "mangrove restoration", "wetland", "mangrove"],
+    perUnit: "per hectare",
+    basePrice: 220000,
+    areaMode: "ceil",
+    referenceAreaSqm: 10000,
+    scaleWithBarangayArea: true,
+    lifecycleYears: 10,
+    materialsShare: 0.5,
+    laborShare: 0.35,
+    maintenanceRate: 0.05,
+    notes: [
+      "Area is converted to hectares; 10,000 m² is treated as one hectare.",
+    ],
+  },
+];
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function normalizeText(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function collectSearchTexts(input: CostEstimateInput): string[] {
+  return [input.interventionType, input.solutionTitle, input.solutionDescription]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => normalizeText(value));
+}
+
+function scoreModelAgainstText(text: string, model: InterventionModel): number {
+  let score = 0;
+  const aliases = [model.key, ...model.aliases].map((value) => normalizeText(value));
+
+  for (const alias of aliases) {
+    if (!alias) continue;
+    if (text === alias) {
+      score += 1000 + alias.length;
+      continue;
+    }
+
+    if (text.includes(alias)) {
+      score += 250 + alias.length;
+      continue;
+    }
+
+    const parts = alias.split(" ").filter(Boolean);
+    if (parts.length > 1 && parts.every((part) => text.includes(part))) {
+      score += 75 + parts.length * 5;
+    }
+  }
+
+  return score;
+}
+
+function roundMoney(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
+function clampMultiplier(value: number): number {
+  return Math.min(1.2, Math.max(0.9, value));
+}
+
+function resolveModel(input: CostEstimateInput): InterventionModel {
+  const texts = collectSearchTexts(input);
+  let bestModel: InterventionModel | null = null;
+  let bestScore = 0;
+
+  for (const model of INTERVENTION_MODELS) {
+    const score = texts.reduce(
+      (runningScore, text) => runningScore + scoreModelAgainstText(text, model),
+      0,
+    );
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestModel = model;
+    }
+  }
+
+  if (bestModel && bestScore > 0) {
+    return bestModel;
+  }
+
+  const normalized = texts.join(" ");
+
+  if (/tree|canopy/.test(normalized)) {
+    return INTERVENTION_MODELS[0];
+  }
+  if (/garden|rain|bioswale|stormwater/.test(normalized)) {
+    return INTERVENTION_MODELS[1];
+  }
+  if (/corridor|blue green|riparian|linear/.test(normalized)) {
+    return INTERVENTION_MODELS[2];
+  }
+  if (/roof|rooftop|building envelope|terrace/.test(normalized)) {
+    return INTERVENTION_MODELS[3];
+  }
+  if (/pavement|paving|porous/.test(normalized)) {
+    return INTERVENTION_MODELS[4];
+  }
+  if (/wall|vertical|facade|living wall/.test(normalized)) {
+    return INTERVENTION_MODELS[5];
+  }
+  if (/wetland|mangrove|marsh|estuary|coastal/.test(normalized)) {
+    return INTERVENTION_MODELS[6];
+  }
+
+  return {
+    key: normalized || "project",
+    aliases: [],
+    perUnit: "per project",
+    basePrice: 10000,
+    areaMode: "none",
+    referenceAreaSqm: 1,
+    scaleWithBarangayArea: false,
+    lifecycleYears: 5,
+    materialsShare: 0.55,
+    laborShare: 0.3,
+    maintenanceRate: 0.05,
+    notes: [
+      "Fallback estimate used because the intervention could not be matched to a calibrated model.",
+    ],
+  };
+}
+
+function deriveScope(
+  scope: CostEstimationScope | null | undefined,
+  areaSqm: number | null,
+): CostEstimationScope {
+  if (scope) return scope;
+  return areaSqm !== null ? "site" : "project";
+}
+
+function resolveQuantity(
+  model: InterventionModel,
+  areaSqm: number | null,
+  scope: CostEstimationScope,
+): number {
+  if (areaSqm === null || model.areaMode === "none") {
+    return 1;
+  }
+
+  const shouldScale = scope === "site" || (scope === "barangay" && model.scaleWithBarangayArea);
+  if (!shouldScale) {
+    return 1;
+  }
+
+  const rawQuantity = areaSqm / model.referenceAreaSqm;
+  if (model.areaMode === "exact") {
+    return Math.max(1, rawQuantity);
+  }
+
+  return Math.max(1, Math.ceil(rawQuantity));
+}
+
+function resolveLocationMultiplier(input: {
+  greeneryIndex?: number | null;
+  floodHazard?: number | null;
+  stormHazard?: number | null;
+  areaSqm: number | null;
+  scope: CostEstimationScope;
+  explicitMultiplier?: number | null;
+}): number {
+  if (isFiniteNumber(input.explicitMultiplier)) {
+    return clampMultiplier(input.explicitMultiplier);
+  }
+
+  let multiplier = 1;
+
+  if (isFiniteNumber(input.greeneryIndex)) {
+    if (input.greeneryIndex < 0.3) {
+      multiplier += 0.06;
+    } else if (input.greeneryIndex < 0.5) {
+      multiplier += 0.03;
+    } else if (input.greeneryIndex > 0.75) {
+      multiplier -= 0.02;
+    }
+  }
+
+  if (isFiniteNumber(input.floodHazard)) {
+    if (input.floodHazard >= 3) {
+      multiplier += 0.08;
+    } else if (input.floodHazard >= 2) {
+      multiplier += 0.05;
+    } else if (input.floodHazard >= 1) {
+      multiplier += 0.02;
+    }
+  }
+
+  if (isFiniteNumber(input.stormHazard)) {
+    if (input.stormHazard >= 3) {
+      multiplier += 0.05;
+    } else if (input.stormHazard >= 2) {
+      multiplier += 0.03;
+    }
+  }
+
+  if (input.areaSqm !== null) {
+    if (input.areaSqm < 100) {
+      multiplier += 0.05;
+    } else if (input.areaSqm > 20000) {
+      multiplier -= 0.04;
+    } else if (input.areaSqm > 5000) {
+      multiplier -= 0.02;
+    }
+  }
+
+  if (input.scope === "barangay") {
+    multiplier += 0.01;
+  }
+
+  return clampMultiplier(multiplier);
+}
+
+export function estimateInterventionCost(
+  input: CostEstimateInput,
+): CostEstimateResult {
+  const model = resolveModel(input);
+  const areaSqm = isFiniteNumber(input.areaSqm) && input.areaSqm > 0 ? input.areaSqm : null;
+  const scope = deriveScope(input.scope, areaSqm);
+  const quantity = resolveQuantity(model, areaSqm, scope);
+  const lifecycleYears =
+    isFiniteNumber(input.lifecycleYears) && input.lifecycleYears > 0
+      ? Math.round(input.lifecycleYears)
+      : model.lifecycleYears;
+
+  const capitalCost = model.basePrice * quantity;
+  const annualMaintenance = capitalCost * model.maintenanceRate;
+  const maintenanceSubtotal = annualMaintenance * lifecycleYears;
+  const locationMultiplier = resolveLocationMultiplier({
+    greeneryIndex: input.greeneryIndex,
+    floodHazard: input.floodHazard,
+    stormHazard: input.stormHazard,
+    areaSqm,
+    scope,
+    explicitMultiplier: input.locationMultiplier,
+  });
+
+  const totalEstimate = roundMoney((capitalCost + maintenanceSubtotal) * locationMultiplier);
+  const materials = roundMoney(capitalCost * model.materialsShare * locationMultiplier);
+  const labor = roundMoney(capitalCost * model.laborShare * locationMultiplier);
+  const maintenance = roundMoney(maintenanceSubtotal * locationMultiplier);
+  const contingency = Math.max(
+    0,
+    totalEstimate - materials - labor - maintenance,
+  );
+
+  const assumptions: string[] = [...model.notes];
+  assumptions.push(`Matched model: ${model.key}.`);
+  assumptions.push(`Lifecycle horizon set to ${lifecycleYears} years.`);
+
+  if (input.barangayId) {
+    assumptions.push(`Barangay context: ${input.barangayId}.`);
+  }
+
+  if (areaSqm !== null) {
+    if (scope === "barangay" && model.scaleWithBarangayArea) {
+      assumptions.push("Barangay-level footprint used for area scaling.");
+    } else if (scope === "site") {
+      assumptions.push("Explicit site footprint used for area scaling.");
+    } else {
+      assumptions.push("Area was provided but not applied to this intervention type.");
+    }
+  } else {
+    assumptions.push("No area input provided, so the estimate falls back to a project-scale unit cost.");
+  }
+
+  if (locationMultiplier !== 1) {
+    assumptions.push("Site-condition multiplier applied from greenery and hazard signals.");
+  }
+
+  return {
+    interventionType: model.key,
+    basePrice: model.basePrice,
+    totalEstimate,
+    currencyUnit: "PHP",
+    perUnit: model.perUnit,
+    area: areaSqm,
+    locationMultiplier,
+    quantity,
+    lifecycleYears,
+    scope,
+    breakdown: {
+      materials,
+      labor,
+      contingency,
+      maintenance,
+    },
+    assumptions,
+  };
+}

--- a/src/types/green_solutions.ts
+++ b/src/types/green_solutions.ts
@@ -85,9 +85,14 @@ export interface CostEstimate {
   perUnit: string;
   area: number | null;
   locationMultiplier: number;
+  quantity?: number;
+  lifecycleYears?: number;
+  scope?: "project" | "site" | "barangay";
   breakdown: {
     materials: number;
     labor: number;
     contingency: number;
+    maintenance?: number;
   };
+  assumptions?: string[];
 }


### PR DESCRIPTION
Key changes

- Added a shared cost-estimation engine for project, site, and barangay scopes.
- Updated the cost-estimate API to infer the correct model from intervention type, title, description, area, greenery index, flood hazard, storm hazard, and lifecycle horizon.
- Expanded the sidebar cost request so it passes the extra context needed for better inference.
- Updated the cost card to show lifecycle maintenance and clearer unit labels.
- Updated the barangay analysis table to use the shared estimator and normalize the PHP values into the existing cost index.
- Included barangay area_km2 in greenery-index responses and made barangay name matching case-insensitive.