### PR TITLE
feat: added research-backed cost estimate

### DIFF
--- a/src/components/ui/green_solutions/SidebarDetails/CostEstimateCard.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/CostEstimateCard.tsx
@@ -1,31 +1,54 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { DollarSign, Package, Wrench, AlertCircle } from "lucide-react";
 import type { CostEstimate } from "@/types/green_solutions";
 
 interface CostEstimateCardProps {
   costEstimate: CostEstimate;
   isLoading?: boolean;
+  siteName?: string;
+  siteAddress?: string;
+  barangayName?: string;
+  areaHectares?: number | null;
 }
 
 export default function CostEstimateCard({
   costEstimate,
   isLoading = false,
+  siteName,
+  siteAddress,
+  barangayName,
+  areaHectares,
 }: CostEstimateCardProps) {
   if (isLoading) {
     return (
-      <div className="p-4 bg-neutral-50 rounded-2xl border border-neutral-100 animate-pulse">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-8 h-8 bg-neutral-200 rounded-lg" />
-          <div className="h-4 w-32 bg-neutral-200 rounded" />
+      <div className="overflow-hidden rounded-[28px] border border-neutral-100 bg-white animate-pulse shadow-sm">
+        <div className="bg-gradient-to-r from-neutral-100 to-neutral-50 px-5 py-5">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-8 h-8 bg-neutral-200 rounded-lg" />
+            <div className="h-4 w-40 bg-neutral-200 rounded" />
+          </div>
+          <div className="h-8 w-52 bg-neutral-200 rounded" />
+          <div className="mt-2 h-4 w-64 bg-neutral-200 rounded" />
         </div>
-        <div className="space-y-3">
-          <div className="h-6 w-24 bg-neutral-200 rounded" />
-          <div className="h-4 w-40 bg-neutral-200 rounded" />
+        <div className="space-y-3 p-5">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="h-20 rounded-2xl bg-neutral-100" />
+            <div className="h-20 rounded-2xl bg-neutral-100" />
+            <div className="h-20 rounded-2xl bg-neutral-100" />
+            <div className="h-20 rounded-2xl bg-neutral-100" />
+          </div>
+          <div className="h-40 rounded-2xl bg-neutral-100" />
         </div>
       </div>
     );
   }
+
+  const totalForShares = costEstimate.totalEstimate || 1;
+  const siteAreaSqm = costEstimate.area;
+  const displayAreaHectares =
+    areaHectares ?? (siteAreaSqm !== null ? siteAreaSqm / 10000 : null);
 
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-PH", {
@@ -36,124 +59,285 @@ export default function CostEstimateCard({
     }).format(amount);
   };
 
+  const formatArea = () => {
+    if (siteAreaSqm === null) {
+      return displayAreaHectares !== null
+        ? `${displayAreaHectares.toFixed(2)} ha`
+        : "Not provided";
+    }
+
+    const areaFormatter = new Intl.NumberFormat("en-PH", {
+      maximumFractionDigits: 0,
+    });
+
+    const hectaresLabel =
+      displayAreaHectares !== null ? ` (${displayAreaHectares.toFixed(2)} ha)` : "";
+
+    return `${areaFormatter.format(siteAreaSqm)} m²${hectaresLabel}`;
+  };
+
+  const siteLabel = siteName?.trim().length ? siteName.trim() : "Selected site";
+  const locationLabel = [siteAddress?.trim(), barangayName?.trim()]
+    .filter((value): value is string => Boolean(value))
+    .join(" • ");
+  const locationAdjustment = (costEstimate.locationMultiplier - 1) * 100;
+
+  const summaryCards = [
+    {
+      label: "Base Cost",
+      value: formatCurrency(costEstimate.basePrice),
+      note: "Before location and project adjustments",
+    },
+    {
+      label: "Site Area",
+      value: formatArea(),
+      note:
+        costEstimate.area === null
+          ? "Area not supplied"
+          : "Area from selected feature",
+    },
+    {
+      label: "Location Multiplier",
+      value: `${costEstimate.locationMultiplier.toFixed(2)}x`,
+      note:
+        locationAdjustment === 0
+          ? "No location adjustment applied"
+          : `${locationAdjustment > 0 ? "+" : ""}${locationAdjustment.toFixed(0)}% from base`,
+    },
+    {
+      label: "Unit Basis",
+      value: costEstimate.perUnit,
+      note: costEstimate.currencyUnit,
+    },
+  ];
+
   return (
-    <div className="space-y-4">
-      {/* Main cost card */}
-      <div className="p-5 bg-gradient-to-br from-green-50 to-emerald-50 rounded-2xl border border-green-200 shadow-sm">
-        <div className="flex items-center gap-2 mb-3">
-          <div className="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center">
-            <DollarSign size={18} className="text-green-700" />
+    <article className="overflow-hidden rounded-[28px] border border-emerald-200 bg-white shadow-sm">
+      <header className="bg-gradient-to-r from-emerald-600 via-green-600 to-lime-500 px-5 py-5 text-white">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1.5">
+            <p className="text-[10px] uppercase tracking-[0.28em] text-white/70">
+              GreenPoint Cost Estimate
+            </p>
+            <h4 className="text-2xl font-black font-poppins leading-tight">
+              Project Cost Estimate
+            </h4>
+            <p className="text-sm text-white/80">Prepared for {siteLabel}</p>
+            {locationLabel ? (
+              <p className="text-xs text-white/70">{locationLabel}</p>
+            ) : null}
           </div>
-          <h4 className="text-xs font-bold text-neutral-400 uppercase tracking-[0.2em]">
-            Cost Estimate
-          </h4>
+
+          <div className="rounded-2xl border border-white/20 bg-white/15 px-4 py-3 text-right shadow-lg shadow-emerald-950/10">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-white/70">
+              Estimated Total
+            </p>
+            <p className="mt-1 text-3xl font-black font-poppins">
+              {formatCurrency(costEstimate.totalEstimate)}
+            </p>
+            <p className="text-xs text-white/75">{costEstimate.perUnit}</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="space-y-5 p-5">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {summaryCards.map((card) => (
+            <StatCard
+              key={card.label}
+              label={card.label}
+              value={card.value}
+              note={card.note}
+            />
+          ))}
         </div>
 
-        <div className="space-y-2">
-          <p className="text-3xl font-bold font-poppins text-green-700">
-            {formatCurrency(costEstimate.totalEstimate)}
-          </p>
-          <p className="text-xs text-neutral-600">
-            {costEstimate.perUnit}{" "}
-            {costEstimate.area ? `• ${costEstimate.area.toFixed(2)} m²` : ""}
-          </p>
-          {costEstimate.locationMultiplier !== 1 && (
-            <p className="text-xs text-neutral-500">
-              Location adjustment:{" "}
-              {((costEstimate.locationMultiplier - 1) * 100).toFixed(0)}%
-            </p>
-          )}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,0.9fr)]">
+          <section className="rounded-2xl border border-neutral-100 bg-neutral-50 p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-white rounded-lg border border-neutral-100 flex items-center justify-center">
+                <DollarSign size={18} className="text-green-700" />
+              </div>
+              <div>
+                <h4 className="text-xs font-bold text-neutral-400 uppercase tracking-[0.2em]">
+                  Cost Breakdown
+                </h4>
+                <p className="text-xs text-neutral-500">
+                  Materials, labor, and contingency contributions.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <BreakdownItem
+                icon={<Package size={16} className="text-blue-600" />}
+                label="Materials"
+                amount={costEstimate.breakdown.materials}
+                shareLabel={formatShare(costEstimate.breakdown.materials, totalForShares)}
+                sharePercent={(costEstimate.breakdown.materials / totalForShares) * 100}
+                barClassName="bg-blue-500"
+              />
+
+              <BreakdownItem
+                icon={<Wrench size={16} className="text-purple-600" />}
+                label="Labor"
+                amount={costEstimate.breakdown.labor}
+                shareLabel={formatShare(costEstimate.breakdown.labor, totalForShares)}
+                sharePercent={(costEstimate.breakdown.labor / totalForShares) * 100}
+                barClassName="bg-purple-500"
+              />
+
+              <BreakdownItem
+                icon={<AlertCircle size={16} className="text-orange-600" />}
+                label="Contingency"
+                amount={costEstimate.breakdown.contingency}
+                shareLabel={formatShare(costEstimate.breakdown.contingency, totalForShares)}
+                sharePercent={(costEstimate.breakdown.contingency / totalForShares) * 100}
+                barClassName="bg-orange-500"
+              />
+            </div>
+          </section>
+
+          <aside className="space-y-4">
+            <section className="rounded-2xl border border-neutral-100 bg-white p-4 space-y-3">
+              <h4 className="text-xs font-bold text-neutral-400 uppercase tracking-[0.2em]">
+                Estimate Context
+              </h4>
+
+              <div className="space-y-2">
+                <DetailRow label="Intervention" value={costEstimate.interventionType} />
+                <DetailRow label="Prepared for" value={siteLabel} />
+                <DetailRow
+                  label="Location"
+                  value={locationLabel || "Selected area"}
+                />
+                <DetailRow label="Area basis" value={formatArea()} />
+                <DetailRow label="Currency" value={costEstimate.currencyUnit} />
+              </div>
+            </section>
+
+            <section className="rounded-2xl border border-amber-100 bg-amber-50 p-4 space-y-2">
+              <h4 className="text-xs font-bold text-amber-700 uppercase tracking-[0.2em]">
+                Notes
+              </h4>
+              <p className="text-sm leading-relaxed text-amber-900/80">
+                Estimate assumes current material pricing, standard site access,
+                and the location adjustment shown above. Final pricing should be
+                confirmed during detailed site assessment.
+              </p>
+            </section>
+          </aside>
+        </div>
+
+        <div className="rounded-2xl border border-neutral-100 bg-white p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h4 className="text-xs font-bold text-neutral-400 uppercase tracking-[0.2em]">
+                Document Summary
+              </h4>
+              <p className="mt-1 text-sm text-neutral-500">
+                This estimate combines the base cost, location adjustment, and
+                contingency into a single project figure.
+              </p>
+            </div>
+
+            <div className="text-right">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-neutral-400">
+                Contingency
+              </p>
+              <p className="mt-1 text-lg font-bold text-neutral-900">
+                {formatCurrency(costEstimate.breakdown.contingency)}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
+    </article>
+  );
+}
 
-      {/* Cost breakdown */}
-      <div className="p-4 bg-neutral-50 rounded-2xl border border-neutral-100 space-y-3">
-        <h4 className="text-xs font-bold text-neutral-400 uppercase tracking-[0.2em]">
-          Cost Breakdown
-        </h4>
+function formatShare(amount: number, total: number) {
+  return `${((amount / total) * 100).toFixed(0)}%`;
+}
 
-        <div className="space-y-2">
-          {/* Materials */}
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-neutral-100">
-            <div className="flex items-center gap-2">
-              <div className="w-7 h-7 bg-blue-50 rounded flex items-center justify-center">
-                <Package size={16} className="text-blue-600" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-neutral-900">
-                  Materials
-                </p>
-                <p className="text-xs text-neutral-500">
-                  {(
-                    (costEstimate.breakdown.materials /
-                      costEstimate.totalEstimate) *
-                    100
-                  ).toFixed(0)}
-                  %
-                </p>
-              </div>
-            </div>
-            <p className="font-bold text-neutral-900">
-              {formatCurrency(costEstimate.breakdown.materials)}
-            </p>
+function StatCard({
+  label,
+  value,
+  note,
+}: {
+  label: string;
+  value: string;
+  note: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-neutral-100 bg-white p-4 shadow-sm">
+      <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-neutral-400">
+        {label}
+      </p>
+      <p className="mt-2 text-base font-semibold text-neutral-900 leading-snug break-words">
+        {value}
+      </p>
+      <p className="mt-2 text-xs text-neutral-500">{note}</p>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-xl bg-neutral-50 px-3 py-2.5">
+      <span className="text-xs font-medium uppercase tracking-[0.16em] text-neutral-400">
+        {label}
+      </span>
+      <span className="max-w-[55%] text-right text-sm font-semibold text-neutral-900 break-words">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function BreakdownItem({
+  icon,
+  label,
+  amount,
+  shareLabel,
+  sharePercent,
+  barClassName,
+}: {
+  icon: ReactNode;
+  label: string;
+  amount: number;
+  shareLabel: string;
+  sharePercent: number;
+  barClassName: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-neutral-100 bg-white p-3.5 space-y-3 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div className="w-8 h-8 rounded-lg bg-neutral-50 border border-neutral-100 flex items-center justify-center shrink-0">
+            {icon}
           </div>
-
-          {/* Labor */}
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-neutral-100">
-            <div className="flex items-center gap-2">
-              <div className="w-7 h-7 bg-purple-50 rounded flex items-center justify-center">
-                <Wrench size={16} className="text-purple-600" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-neutral-900">Labor</p>
-                <p className="text-xs text-neutral-500">
-                  {(
-                    (costEstimate.breakdown.labor /
-                      costEstimate.totalEstimate) *
-                    100
-                  ).toFixed(0)}
-                  %
-                </p>
-              </div>
-            </div>
-            <p className="font-bold text-neutral-900">
-              {formatCurrency(costEstimate.breakdown.labor)}
-            </p>
-          </div>
-
-          {/* Contingency */}
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg border border-neutral-100">
-            <div className="flex items-center gap-2">
-              <div className="w-7 h-7 bg-orange-50 rounded flex items-center justify-center">
-                <AlertCircle size={16} className="text-orange-600" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-neutral-900">
-                  Contingency
-                </p>
-                <p className="text-xs text-neutral-500">
-                  {(
-                    (costEstimate.breakdown.contingency /
-                      costEstimate.totalEstimate) *
-                    100
-                  ).toFixed(0)}
-                  %
-                </p>
-              </div>
-            </div>
-            <p className="font-bold text-neutral-900">
-              {formatCurrency(costEstimate.breakdown.contingency)}
-            </p>
+          <div>
+            <p className="text-sm font-semibold text-neutral-900">{label}</p>
+            <p className="text-xs text-neutral-500">{shareLabel} of total</p>
           </div>
         </div>
 
-        {/* Cost info */}
-        <div className="pt-2 border-t border-neutral-200">
-          <p className="text-xs text-neutral-500">
-            Base cost: {formatCurrency(costEstimate.basePrice)} • Estimate may
-            vary based on site conditions
-          </p>
-        </div>
+        <p className="font-bold text-neutral-900 whitespace-nowrap">
+          {new Intl.NumberFormat("en-PH", {
+            style: "currency",
+            currency: "PHP",
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0,
+          }).format(amount)}
+        </p>
+      </div>
+
+      <div className="h-2 overflow-hidden rounded-full bg-neutral-100">
+        <div
+          className={`h-full rounded-full ${barClassName}`}
+          style={{ width: `${Math.max(0, Math.min(100, sharePercent))}%` }}
+        />
       </div>
     </div>
   );

--- a/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
@@ -27,19 +27,36 @@ export default function InfoTab({
     !recommendation.costEstimate,
   );
 
+  const selectedAreaSqm =
+    selectedFeature.customSelectionAreaHectares !== undefined &&
+    selectedFeature.customSelectionAreaHectares !== null
+      ? selectedFeature.customSelectionAreaHectares * 10000
+      : null;
+
+  const selectedBarangayId =
+    selectedFeature.barangay.trim().length > 0
+      ? selectedFeature.barangay
+      : null;
+
+  const interventionType =
+    recommendation.interventionType || recommendation.solutionTitle;
+
   useEffect(() => {
-    // If cost estimate is already provided, skip fetching
     if (recommendation.costEstimate) {
       setCostEstimate(recommendation.costEstimate);
       setIsLoadingCost(false);
       return;
     }
 
-    // Fetch cost estimate from API
     const fetchCostEstimate = async () => {
+      setIsLoadingCost(true);
+      setCostEstimate(null);
+
       try {
         const params = new URLSearchParams({
-          interventionType: recommendation.solutionTitle,
+          interventionType,
+          ...(selectedAreaSqm !== null && { area: selectedAreaSqm.toString() }),
+          ...(selectedBarangayId && { barangayId: selectedBarangayId }),
         });
 
         const response = await fetch(`/api/cost-estimate?${params}`);
@@ -55,8 +72,13 @@ export default function InfoTab({
       }
     };
 
-    fetchCostEstimate();
-  }, [recommendation]);
+    void fetchCostEstimate();
+  }, [
+    interventionType,
+    recommendation.costEstimate,
+    selectedAreaSqm,
+    selectedBarangayId,
+  ]);
 
   return (
     <div className="sm:px-2 lg:px-6 h-full overflow-y-auto space-y-6 scrollbar-hide">
@@ -110,10 +132,14 @@ export default function InfoTab({
       {/* ── Cost Estimate ── */}
       {costEstimate && (
         <section>
-          <SectionLabel>Project Cost</SectionLabel>
+          <SectionLabel>Cost Estimate Document</SectionLabel>
           <CostEstimateCard
             costEstimate={costEstimate}
             isLoading={isLoadingCost}
+            siteName={selectedFeature.name}
+            siteAddress={selectedFeature.address}
+            barangayName={selectedFeature.barangay}
+            areaHectares={selectedFeature.customSelectionAreaHectares}
           />
         </section>
       )}


### PR DESCRIPTION
Summary
Adds a document-style cost estimate panel to the Green Solutions sidebar. The estimate now uses the selected intervention type and site context, including area and barangay when available, so the totals better reflect the chosen location.

Key Changes
- Reworked the estimate UI into a report-style card with site details and breakdowns.
- Updated the estimate request to use the actual intervention type and selected area/location data.

How To Test
- Open a recommendation in the sidebar.
- Select a feature with a barangay or custom area.
- Confirm the cost estimate renders and reflects the selected site context.

Validation
- Ran lint on the touched estimate components.