### PR TITLE
fix(map): Stop map from loading after every mode and layer switch. Im…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -144,36 +144,100 @@
 /* ---Chloroplet Map Custom CSS---*/
 
 .legend {
-  line-height: 18px;
-  color: #555;
-  background: white;
-  padding: 10px;
-  border-radius: 8px;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
-  font-size: 13px;
+  color: #334155;
+  background: rgba(255, 255, 255, 0.94);
+  padding: 6px 7px 2px;
+  border-radius: 7px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.1);
+  min-width: 132px;
+  font-size: 10px;
 }
 
 .dark .legend {
   color: #e5e7eb;
-  background: #111827;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.45);
+  background: rgba(17, 24, 39, 0.94);
+  border-color: rgba(71, 85, 105, 0.5);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
 }
 
 .legend h4 {
-  margin: 0 0 5px;
-  color: #333;
+  margin: 0;
+  color: #0f172a;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 .dark .legend h4 {
   color: #f9fafb;
 }
 
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin-right: 8px;
-  opacity: 0.8;
+.legend-title-wrap {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 4px;
+}
+
+.legend-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.legend-gradient-wrap {
+  position: relative;
+  width: 118px;
+  padding-bottom: 9px;
+}
+
+.legend-gradient-track {
+  position: relative;
+  width: 100%;
+  height: 7px;
+  border-radius: 9999px;
+  border: 1px solid rgba(15, 23, 42, 0.24);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+}
+
+.dark .legend-gradient-track {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.legend-gradient-fill {
+  height: 100%;
+  width: 100%;
+  border-radius: inherit;
+}
+
+.legend-scale-row {
+  position: relative;
+  height: 10px;
+  margin-top: 2px;
+}
+
+.legend-scale-tick {
+  position: absolute;
+  top: 0;
+  font-size: 8px;
+  font-weight: 600;
+  color: #0f172a;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  transform: translateX(-50%);
+}
+
+.legend-scale-tick:first-child {
+  transform: translateX(0%);
+}
+
+.legend-scale-tick:last-child {
+  transform: translateX(-100%);
+}
+
+.dark .legend-scale-tick {
+  color: #f8fafc;
 }
 
 .leaflet-interactive:focus {

--- a/src/components/landing/landing-map-mount.tsx
+++ b/src/components/landing/landing-map-mount.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 const MandaueMap = dynamic(
   () => import("@/components/ui/dashboard/ChloropletMap"),
@@ -17,6 +17,14 @@ const MandaueMap = dynamic(
     ),
   },
 );
+
+const StableLandingMandaueMap = memo(function StableLandingMandaueMap({
+  settings,
+}: {
+  settings: boolean;
+}) {
+  return <MandaueMap settings={settings} />;
+});
 
 /**
  * Defers downloading/parsing the Leaflet choropleth chunk until the map column
@@ -58,7 +66,7 @@ export default function LandingMapMount({ settings }: { settings: boolean }) {
       className="w-full h-[260px] sm:h-[320px] md:h-[380px] lg:w-[430px] lg:h-[480px] border-2 sm:border-4 border-primary-green/40 dark:border-emerald-500/30 overflow-hidden rounded-lg sm:rounded-xl shadow-xl shadow-black/5 dark:shadow-black/30 bg-white dark:bg-neutral-900"
     >
       {show ? (
-        <MandaueMap settings={settings} />
+        <StableLandingMandaueMap settings={settings} />
       ) : (
         <div
           className="flex h-full min-h-[260px] w-full items-center justify-center bg-emerald-50/50 text-sm font-medium text-neutral-500"

--- a/src/components/map/map_wrapper.tsx
+++ b/src/components/map/map_wrapper.tsx
@@ -52,6 +52,7 @@ export default function MapWrapper({
   const [isLayersPanelOpen, setIsLayersPanelOpen] = useState(false);
 
   const [selectedMapType, setSelectedMapType] = useState("Default");
+  const effectiveStyleUrl = mapStyles[selectedMapType] ?? mapStyles.Default;
   const [layerColors, setLayerColors] = useState(defaultLayerColors);
   const [layerVisibility, setLayerVisibility] = useState(
     defaultLayerVisibility,
@@ -85,7 +86,7 @@ export default function MapWrapper({
   return (
     <div className="relative h-full w-screen bg-background font-roboto text-foreground">
       <MapboxMap
-        styleUrl={mapStyles[selectedMapType]}
+        styleUrl={effectiveStyleUrl}
         layerVisibility={layerVisibility}
         layerColors={layerColors}
         layerSpecificSelected={layerSpecificSelected}

--- a/src/components/map/mapbox_map.tsx
+++ b/src/components/map/mapbox_map.tsx
@@ -109,10 +109,12 @@ export default function MapboxMap({
   const selectionModeRef = useRef(selectionMode);
   const onBarangaySelectedRef = useRef(onBarangaySelected);
   const onMapReadyRef = useRef(onMapReady);
+  const onFeatureSelectedRef = useRef(onFeatureSelected);
   const layerVisibilityRef = useRef(layerVisibility);
   const layerColorsRef = useRef(layerColors);
   const layerSpecificSelectedRef = useRef(layerSpecificSelected);
   const handleSelectionRef = useRef<SelectionHandler | null>(null);
+  const pendingLayerSyncFrameRef = useRef<number | null>(null);
 
   const removeMarker = useCallback(() => {
     if (markerRef.current) {
@@ -218,7 +220,7 @@ export default function MapboxMap({
       feature: mapboxgl.GeoJSONFeature,
       coords: { lng: number; lat: number },
       barangay: string,
-      mode: LocationSelectionMode = selectionMode,
+      mode?: LocationSelectionMode,
       customSelectionGeometry: GeoJSON.Polygon | null = null,
       customSelectionAreaHectares: number | null = null,
       placeMarker = true,
@@ -231,15 +233,39 @@ export default function MapboxMap({
         barangay,
         mapRef.current,
         markerRef,
-        onFeatureSelected,
-        mode,
+        onFeatureSelectedRef.current,
+        mode ?? selectionModeRef.current,
         customSelectionGeometry,
         customSelectionAreaHectares,
         placeMarker,
       );
     },
-    [onFeatureSelected, selectionMode],
+    [],
   );
+
+  const runLayerSync = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+
+    syncLayerStyles(
+      map,
+      layerVisibilityRef.current,
+      layerColorsRef.current,
+      layerSpecificSelectedRef.current,
+      selectionModeRef.current,
+    );
+  }, []);
+
+  const scheduleLayerSync = useCallback(() => {
+    if (pendingLayerSyncFrameRef.current !== null) {
+      cancelAnimationFrame(pendingLayerSyncFrameRef.current);
+    }
+
+    pendingLayerSyncFrameRef.current = requestAnimationFrame(() => {
+      pendingLayerSyncFrameRef.current = null;
+      runLayerSync();
+    });
+  }, [runLayerSync]);
 
   useEffect(() => {
     selectionModeRef.current = selectionMode;
@@ -252,6 +278,10 @@ export default function MapboxMap({
   useEffect(() => {
     onMapReadyRef.current = onMapReady;
   }, [onMapReady]);
+
+  useEffect(() => {
+    onFeatureSelectedRef.current = onFeatureSelected;
+  }, [onFeatureSelected]);
 
   useEffect(() => {
     layerVisibilityRef.current = layerVisibility;
@@ -312,7 +342,7 @@ export default function MapboxMap({
 
     const map = new mapboxgl.Map({
       container: mapContainer.current,
-      style: styleUrl,
+      style: currentStyleRef.current,
       center,
       zoom,
     });
@@ -322,37 +352,47 @@ export default function MapboxMap({
     const handleStyleLoad = () => {
       addBarangayBounds(map);
       addHazardLayers(map, layerColorsRef.current);
-      syncLayerStyles(
-        map,
-        layerVisibilityRef.current,
-        layerColorsRef.current,
-        layerSpecificSelectedRef.current,
-        selectionModeRef.current,
-      );
+      scheduleLayerSync();
       applyOverlayClipping(map);
       ensureCustomSelectionLayers(map);
       syncSelectedCustomAreaOverlay(map, selectedCustomAreaRef.current);
       syncDraftCustomAreaOverlay(map, customDrawingPointsRef.current);
 
-      if (selectionMode === "custom") {
+      if (selectionModeRef.current === "custom") {
         map.dragPan.disable();
         map.getCanvas().style.cursor = "crosshair";
       } else {
         map.dragPan.enable();
       }
 
-      if (onMapReady) onMapReady(map, removeMarker);
+      onMapReadyRef.current?.(map, removeMarker);
+    };
+
+    const handleInitialLoad = () => {
+      scheduleLayerSync();
     };
 
     map.on("style.load", handleStyleLoad);
+    map.on("load", handleInitialLoad);
+    map.once("idle", handleInitialLoad);
+    const handleStyleData = () => {
+      if (!map.isStyleLoaded()) return;
+      scheduleLayerSync();
+    };
+    map.on("styledata", handleStyleData);
+
+    if (map.isStyleLoaded()) {
+      handleStyleLoad();
+    }
 
     const handleClick = (e: mapboxgl.MapMouseEvent) => {
-      if (selectionMode === "custom") {
+      const mode = selectionModeRef.current;
+      if (mode === "custom") {
         return;
       }
 
       const featuresAtPoint = map.queryRenderedFeatures(e.point);
-      if (selectionMode === "poi") {
+      if (mode === "poi") {
         const poiFeature = featuresAtPoint.find((f) => f.layer?.id === "poi-label");
         if (poiFeature) {
           const brgyFeatures = map.queryRenderedFeatures(e.point, {
@@ -363,14 +403,14 @@ export default function MapboxMap({
             "Unknown Barangay";
           void handleSelection(poiFeature, e.lngLat, brgyName, "poi");
         }
-      } else if (selectionModeRef.current === "barangay") {
+      } else if (mode === "barangay") {
         const brgyFeature = featuresAtPoint.find(
           (f) => f.layer?.id === "barangayBounds",
         );
         if (brgyFeature) {
           const name = brgyFeature.properties?.name as string | undefined;
           void handleSelection(brgyFeature, e.lngLat, name || "", "barangay");
-          if (onBarangaySelected && name) onBarangaySelected(name);
+          if (name) onBarangaySelectedRef.current?.(name);
           map.setPaintProperty("barangayBounds", "fill-color", [
             "match",
             ["get", "name"],
@@ -385,7 +425,7 @@ export default function MapboxMap({
     map.on("click", handleClick);
 
     const handleMouseMove = (e: mapboxgl.MapMouseEvent) => {
-      if (selectionMode === "barangay") {
+      if (selectionModeRef.current === "barangay") {
         if (!map.getLayer("barangayBounds")) return;
 
         const features = map.queryRenderedFeatures(e.point, {
@@ -402,7 +442,7 @@ export default function MapboxMap({
     const canvasContainer = map.getCanvasContainer();
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (selectionMode !== "custom" || event.button !== 0) return;
+      if (selectionModeRef.current !== "custom" || event.button !== 0) return;
 
       event.preventDefault();
       customDrawingActiveRef.current = true;
@@ -429,7 +469,7 @@ export default function MapboxMap({
     };
 
     const handlePointerMove = (event: PointerEvent) => {
-      if (selectionMode !== "custom") return;
+      if (selectionModeRef.current !== "custom") return;
 
       map.getCanvas().style.cursor = "crosshair";
 
@@ -459,7 +499,7 @@ export default function MapboxMap({
     };
 
     const completeCustomSelection = async (event?: PointerEvent) => {
-      if (selectionMode !== "custom" || !customDrawingActiveRef.current) return;
+      if (selectionModeRef.current !== "custom" || !customDrawingActiveRef.current) return;
 
       customDrawingActiveRef.current = false;
       if (event) {
@@ -492,8 +532,8 @@ export default function MapboxMap({
         (barangayFeatures[0]?.properties?.name as string | undefined) || "";
 
       syncSelectedCustomAreaOverlay(map, polygon);
-      if (barangay && onBarangaySelected) {
-        onBarangaySelected(barangay);
+      if (barangay) {
+        onBarangaySelectedRef.current?.(barangay);
       }
 
       const customFeature = {
@@ -521,13 +561,13 @@ export default function MapboxMap({
     };
 
     const handlePointerUp = (event: PointerEvent) => {
-      if (selectionMode !== "custom") return;
+      if (selectionModeRef.current !== "custom") return;
 
       void completeCustomSelection(event);
     };
 
     const handlePointerCancel = () => {
-      if (selectionMode !== "custom") return;
+      if (selectionModeRef.current !== "custom") return;
 
       customDrawingActiveRef.current = false;
       customDrawingPointsRef.current = [];
@@ -546,6 +586,8 @@ export default function MapboxMap({
 
     return () => {
       map.off("style.load", handleStyleLoad);
+      map.off("load", handleInitialLoad);
+      map.off("styledata", handleStyleData);
       map.off("click", handleClick);
       map.off("mousemove", handleMouseMove);
       canvasContainer.removeEventListener("pointerdown", handlePointerDown);
@@ -554,24 +596,17 @@ export default function MapboxMap({
       canvasContainer.removeEventListener("pointercancel", handlePointerCancel);
       map.remove();
       mapRef.current = null;
+      if (pendingLayerSyncFrameRef.current !== null) {
+        cancelAnimationFrame(pendingLayerSyncFrameRef.current);
+        pendingLayerSyncFrameRef.current = null;
+      }
     };
-  }, [
-    center,
-    zoom,
-    layerVisibility,
-    layerColors,
-    layerSpecificSelected,
-    styleUrl,
-    selectionMode,
-    onMapReady,
-    removeMarker,
-    handleSelection,
-    onBarangaySelected,
-    ensureCustomSelectionLayers,
-    syncSelectedCustomAreaOverlay,
-    syncDraftCustomAreaOverlay,
-    clearDraftCustomAreaOverlay,
-  ]);
+    // Map instance must only be created once. All dynamic inputs
+    // (layerVisibility, selectionMode, styleUrl, center/zoom, callbacks)
+    // flow through refs and their own dedicated effects below so the
+    // underlying mapboxgl.Map is never re-created.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -616,22 +651,17 @@ export default function MapboxMap({
   }, []);
 
   useEffect(() => {
-    if (mapRef.current && mapRef.current.isStyleLoaded()) {
-      syncLayerStyles(
-        mapRef.current,
-        layerVisibility,
-        layerColors,
-        layerSpecificSelected,
-        selectionMode,
-      );
-      if (selectionMode === "custom") {
-        mapRef.current.getCanvas().style.cursor = "crosshair";
-        mapRef.current.dragPan.disable();
-      } else {
-        mapRef.current.dragPan.enable();
-      }
+    if (!mapRef.current || !mapRef.current.isStyleLoaded()) return;
+
+    scheduleLayerSync();
+
+    if (selectionMode === "custom") {
+      mapRef.current.getCanvas().style.cursor = "crosshair";
+      mapRef.current.dragPan.disable();
+    } else {
+      mapRef.current.dragPan.enable();
     }
-  }, [layerVisibility, layerColors, layerSpecificSelected, selectionMode]);
+  }, [layerVisibility, layerColors, layerSpecificSelected, selectionMode, scheduleLayerSync]);
 
   useEffect(() => {
     if (mapRef.current && currentStyleRef.current !== styleUrl) {

--- a/src/components/ui/dashboard/ChloropletMap.tsx
+++ b/src/components/ui/dashboard/ChloropletMap.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import dynamic from "next/dynamic";
 import type {
   Layer,
@@ -7,6 +7,7 @@ import type {
   TooltipOptions,
   StyleFunction,
   Tooltip,
+  Map as LeafletMap,
 } from "leaflet";
 import type { Feature } from "geojson";
 import {
@@ -19,7 +20,7 @@ import {
   mergeGI,
 } from "@/lib/MergeGI";
 import { fetchGreeneryIndexResourceDeduped } from "@/lib/data-api/greenery-index-resource-client";
-import { useBarangay } from "@/context/BarangayContext";
+import { useBarangayActions } from "@/context/BarangayContext";
 import { useTheme } from "@/context/ThemeContext";
 import { useGeoData } from "@/context/geoDataStore";
 import "leaflet/dist/leaflet.css";
@@ -76,17 +77,72 @@ interface MandaueMapProps {
   readonly settings?: boolean;
 }
 
-export default function MandaueMap({ settings = true }: MandaueMapProps) {
+function MandaueMap({ settings = true }: MandaueMapProps) {
   const geoData = useGeoData((state) => state.geoData);
-  const isClient = useGeoData((state) => state.isClient);
   const setGeoData = useGeoData((state) => state.setGeoData);
-  const setIsClient = useGeoData((state) => state.setIsClient);
-  const { setSelectedBarangay } = useBarangay();
+  const mapView = useGeoData((state) => state.mapView);
+  const setMapView = useGeoData((state) => state.setMapView);
+  const { setSelectedBarangay } = useBarangayActions();
   const { isDarkMode } = useTheme();
+  const renderCountRef = useRef(0);
+  const mapRef = useRef<LeafletMap | null>(null);
+
+  renderCountRef.current += 1;
+
+  const initialCenter = useMemo<[number, number]>(() => {
+    if (mapView?.center) return mapView.center;
+    return settings ? DASHBOARD_MAP_CENTER : LANDING_MAP_CENTER;
+    // Intentional: only compute once at mount to seed MapContainer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const initialZoom = useMemo<number>(() => {
+    if (typeof mapView?.zoom === "number") return mapView.zoom;
+    return settings ? DASHBOARD_MAP_ZOOM : LANDING_MAP_ZOOM;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleMapReady = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const persist = () => {
+      const c = map.getCenter();
+      setMapView({ center: [c.lat, c.lng], zoom: map.getZoom() });
+    };
+
+    map.on("moveend", persist);
+    map.on("zoomend", persist);
+  }, [setMapView]);
 
   useEffect(() => {
-    setIsClient(true);
+    return () => {
+      const map = mapRef.current;
+      if (!map) return;
+      map.off("moveend");
+      map.off("zoomend");
+    };
+  }, []);
 
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    console.debug("[MandaueMap] mounted");
+    return () => {
+      console.debug("[MandaueMap] unmounted");
+    };
+  }, []);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    console.debug("[MandaueMap] render", {
+      count: renderCountRef.current,
+      isDarkMode,
+      hasGeoData: Boolean(geoData),
+      settings,
+    });
+  }, [geoData, isDarkMode, settings]);
+
+  useEffect(() => {
     // Fix for Leaflet icon in Next.js SSR
     if (globalThis.window !== undefined) {
       import("leaflet").then((L) => {
@@ -102,7 +158,7 @@ export default function MandaueMap({ settings = true }: MandaueMapProps) {
         });
       });
     }
-  }, [setIsClient]);
+  }, []);
 
   useEffect(() => {
     Promise.all([
@@ -130,7 +186,21 @@ export default function MandaueMap({ settings = true }: MandaueMapProps) {
       .catch((err) => console.error("GeoJSON load error:", err));
   }, [setGeoData]);
 
-  const onEachFeature = (
+  const tileLayers = useMemo(
+    () => ({
+      light: {
+        url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        attribution: "© OpenStreetMap contributors",
+      },
+      dark: {
+        url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+        attribution: "© OpenStreetMap contributors © CARTO",
+      },
+    }),
+    [],
+  );
+
+  const onEachFeature = useCallback((
     feature: BarangayFeature,
     layer: Layer & {
       bindTooltip: (content: string, options?: TooltipOptions) => void;
@@ -234,33 +304,24 @@ export default function MandaueMap({ settings = true }: MandaueMapProps) {
         layer.bindPopup(`<b>${feature.properties.name}</b>`).openPopup();
       });
     }
-  };
+  }, [setSelectedBarangay]);
 
   // Default style for the barangay boundaries
-  const style = (feature: BarangayFeature) => ({
-    fillColor: getGreeneryColor(feature.properties.greenery_index ?? 0),
-    weight: BARANGAY_OUTLINE.weight,
-    opacity: 1,
-    color: BARANGAY_OUTLINE.color,
-    fillOpacity: BARANGAY_OUTLINE.fillOpacity,
-  });
-
-  if (!isClient) {
-    return (
-      <div className="w-full h-full rounded-lg overflow-hidden shadow flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-green mx-auto mb-2"></div>
-          <p className="text-neutral-black/60 dark:text-neutral-400">Loading map...</p>
-        </div>
-      </div>
-    );
-  }
+  const style = useCallback((feature: BarangayFeature) => {
+    return {
+      fillColor: getGreeneryColor(feature.properties.greenery_index ?? 0),
+      weight: BARANGAY_OUTLINE.weight,
+      opacity: 1,
+      color: BARANGAY_OUTLINE.color,
+      fillOpacity: BARANGAY_OUTLINE.fillOpacity,
+    };
+  }, []);
 
   return (
     <div className="w-full h-full overflow-hidden shadow z-40">
       <MapContainer
-        center={settings ? DASHBOARD_MAP_CENTER : LANDING_MAP_CENTER}
-        zoom={settings ? DASHBOARD_MAP_ZOOM : LANDING_MAP_ZOOM}
+        center={initialCenter}
+        zoom={initialZoom}
         dragging={settings}
         zoomControl={settings}
         scrollWheelZoom={settings}
@@ -270,18 +331,22 @@ export default function MandaueMap({ settings = true }: MandaueMapProps) {
         keyboard={settings}
         attributionControl={settings}
         style={{ height: "100%", width: "100%" }}
+        ref={(instance) => {
+          mapRef.current = instance ?? null;
+        }}
+        whenReady={handleMapReady}
       >
         <TileLayer
-          url={
-            isDarkMode
-              ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-              : "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          }
-          attribution={
-            isDarkMode
-              ? "© OpenStreetMap contributors © CARTO"
-              : "© OpenStreetMap contributors"
-          }
+          url={tileLayers.light.url}
+          attribution={tileLayers.light.attribution}
+          opacity={isDarkMode ? 0 : 1}
+          zIndex={1}
+        />
+        <TileLayer
+          url={tileLayers.dark.url}
+          attribution={tileLayers.dark.attribution}
+          opacity={isDarkMode ? 1 : 0}
+          zIndex={2}
         />
         {geoData && (
           <GeoJSON
@@ -295,3 +360,5 @@ export default function MandaueMap({ settings = true }: MandaueMapProps) {
     </div>
   );
 }
+
+export default memo(MandaueMap);

--- a/src/components/ui/dashboard/CityGreeneryMap.tsx
+++ b/src/components/ui/dashboard/CityGreeneryMap.tsx
@@ -31,6 +31,10 @@ const ChoroplethMap = dynamic(() => import("./ChloropletMap"), {
   ),
 });
 
+const StableChoroplethMap = React.memo(function StableChoroplethMap() {
+  return <ChoroplethMap />;
+});
+
 export default function CityGreeneryMap() {
   const [isOpen, setIsOpen] = React.useState(false);
   const { selectedBarangay } = useBarangay();
@@ -63,7 +67,7 @@ export default function CityGreeneryMap() {
         </h2>
         <div className="flex w-full flex-1 flex-col overflow-hidden rounded-lg border bg-white dark:bg-neutral-900 dark:border-neutral-800 shadow-sm shadow-black/5 dark:shadow-black/20 md:flex-row">
           <div className="h-72 w-full overflow-hidden border-b border-neutral-200 dark:border-neutral-800 md:h-auto md:w-2/3 md:border-b-0 md:border-r">
-            <ChoroplethMap />
+            <StableChoroplethMap />
           </div>
           <aside className="flex w-full flex-1 flex-col items-center gap-4 bg-white dark:bg-neutral-900 p-4 px-6 md:w-1/3">
             <div className="flex w-full items-center gap-2">

--- a/src/components/ui/dashboard/greeneryLegend.tsx
+++ b/src/components/ui/dashboard/greeneryLegend.tsx
@@ -3,10 +3,7 @@
 import { useEffect } from "react";
 import { useMap } from "react-leaflet";
 import L from "leaflet";
-import {
-  GREENERY_INDEX_FILL_STOPS,
-  interpolateGreeneryIndexFillColor,
-} from "@/lib/chloroplet-colors";
+import { getGreeneryColor } from "@/lib/chloroplet-colors";
 
 export default function GreeneryLegend() {
   const map = useMap();
@@ -16,28 +13,36 @@ export default function GreeneryLegend() {
 
     legend.onAdd = function () {
       const div = L.DomUtil.create("div", "info legend");
-      const labels: string[] = [];
-      div.innerHTML += "<h4>Greenery Index</h4>";
+      const steps = 14;
+      const gradientStops = Array.from({ length: steps + 1 }, (_, index) => {
+        const value = index / steps;
+        return `${getGreeneryColor(value)} ${(value * 100).toFixed(0)}%`;
+      });
+      const scaleTicks = [0, 0.25, 0.5, 0.75, 1];
 
-      const first = GREENERY_INDEX_FILL_STOPS[0];
-      const lowMid = first.value / 2;
-      labels.push(
-        `<i style="background:${interpolateGreeneryIndexFillColor(lowMid)}"></i> 0 – ${first.value}`,
-      );
-      for (let i = 0; i < GREENERY_INDEX_FILL_STOPS.length - 1; i++) {
-        const from = GREENERY_INDEX_FILL_STOPS[i].value;
-        const to = GREENERY_INDEX_FILL_STOPS[i + 1].value;
-        const mid = (from + to) / 2;
-        labels.push(
-          `<i style="background:${interpolateGreeneryIndexFillColor(mid)}"></i> ${from} – ${to}`,
-        );
-      }
-      const last = GREENERY_INDEX_FILL_STOPS[GREENERY_INDEX_FILL_STOPS.length - 1];
-      labels.push(
-        `<i style="background:${last.color}"></i> ${last.value} – 1`,
-      );
-
-      div.innerHTML += labels.join("<br>");
+      div.innerHTML = `
+        <div class="legend-title-wrap">
+          <h4>Greenery Index</h4>
+        </div>
+        <div class="legend-body">
+          <div class="legend-gradient-wrap">
+            <div class="legend-gradient-track">
+              <div class="legend-gradient-fill" style="background: linear-gradient(to right, ${gradientStops.join(", ")});"></div>
+            </div>
+            <div class="legend-scale-row">
+              ${scaleTicks
+                .map(
+                  (value) => `
+                    <span class="legend-scale-tick" style="left:${(value * 100).toFixed(0)}%">
+                      ${value === 0 || value === 1 ? value.toFixed(0) : value.toFixed(2)}
+                    </span>
+                  `,
+                )
+                .join("")}
+            </div>
+          </div>
+        </div>
+      `;
       return div;
     };
 

--- a/src/context/BarangayContext.tsx
+++ b/src/context/BarangayContext.tsx
@@ -19,7 +19,15 @@ interface BarangayContextType {
   setSimulationBarangay: (barangay: BarangayData | null) => void;
 }
 
+interface BarangayActionsContextType {
+  setSelectedBarangay: (barangay: BarangayData | null) => void;
+  setSimulationBarangay: (barangay: BarangayData | null) => void;
+}
+
 const BarangayContext = createContext<BarangayContextType | undefined>(
+  undefined,
+);
+const BarangayActionsContext = createContext<BarangayActionsContextType | undefined>(
   undefined,
 );
 
@@ -38,11 +46,20 @@ export const BarangayProvider = ({ children }: { children: ReactNode }) => {
     }),
     [selectedBarangay, simulationBarangay],
   );
+  const actionsValue = useMemo(
+    () => ({
+      setSelectedBarangay,
+      setSimulationBarangay,
+    }),
+    [],
+  );
 
   return (
-    <BarangayContext.Provider value={contextValue}>
-      {children}
-    </BarangayContext.Provider>
+    <BarangayActionsContext.Provider value={actionsValue}>
+      <BarangayContext.Provider value={contextValue}>
+        {children}
+      </BarangayContext.Provider>
+    </BarangayActionsContext.Provider>
   );
 };
 
@@ -50,6 +67,14 @@ export function useBarangay() {
   const context = useContext(BarangayContext);
   if (!context) {
     throw new Error("useBarangay must be used within a BarangayProvider");
+  }
+  return context;
+}
+
+export function useBarangayActions() {
+  const context = useContext(BarangayActionsContext);
+  if (!context) {
+    throw new Error("useBarangayActions must be used within a BarangayProvider");
   }
   return context;
 }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 type ThemePreference = "light" | "dark";
 
@@ -71,16 +72,21 @@ export function ThemeProvider({
     persistTheme(shouldBeDark);
   }, [initialTheme, themeFromCookie]);
 
-  const toggleDarkMode = () => {
+  const toggleDarkMode = useCallback(() => {
     setIsDarkMode((prev) => {
       const newValue = !prev;
       persistTheme(newValue);
       return newValue;
     });
-  };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ isDarkMode, toggleDarkMode }),
+    [isDarkMode, toggleDarkMode],
+  );
 
   return (
-    <ThemeContext.Provider value={{ isDarkMode, toggleDarkMode }}>
+    <ThemeContext.Provider value={contextValue}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/context/geoDataStore.ts
+++ b/src/context/geoDataStore.ts
@@ -1,17 +1,25 @@
 import { create } from "zustand";
 import type { FeatureCollection } from "geojson";
 
+export interface MapView {
+  center: [number, number];
+  zoom: number;
+}
+
 interface GeoDataState {
   geoData: FeatureCollection | null;
   isClient: boolean;
+  mapView: MapView | null;
   setGeoData: (data: FeatureCollection) => void;
   setIsClient: (value: boolean) => void;
+  setMapView: (view: MapView) => void;
 }
 
 export const useGeoData = create<GeoDataState>((set) => ({
   geoData: null,
   isClient: false,
+  mapView: null,
   setGeoData: (data) => set({ geoData: data }),
   setIsClient: (value) => set({ isClient: value }),
+  setMapView: (view) => set({ mapView: view }),
 }));
-

--- a/src/lib/chloroplet-colors.ts
+++ b/src/lib/chloroplet-colors.ts
@@ -74,7 +74,12 @@ export function mapboxGreeneryIndexFillColorExpression(): unknown[] {
 
 /** Choropleth / legend — alias for explore-aligned ramp. */
 export function getGreeneryColor(value: number): string {
-  return interpolateGreeneryIndexFillColor(value);
+  // Continuous hue ramp (red -> green) for smoother, less categorical look.
+  const clamped = Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+  const hue = 10 + clamped * 120; // 10 = warm red/orange, 130 = green
+  const saturation = 68; // stable chroma for readability
+  const lightness = 50; // balanced against map tiles in both themes
+  return `hsl(${hue.toFixed(1)} ${saturation}% ${lightness}%)`;
 }
 
 export function getGreeneryClassColor(value: number): string {

--- a/src/lib/data-api/client.ts
+++ b/src/lib/data-api/client.ts
@@ -16,18 +16,48 @@ type PointApiResponse = {
   data: PointEnvironmentalPayload;
 };
 
+let mapEnvBundleCache: MapEnvBundle | null = null;
+let mapEnvBundlePromise: Promise<MapEnvBundle> | null = null;
+
 export async function fetchMapEnvBundle(
   include?: string,
 ): Promise<MapEnvBundle> {
+  // Cache only full default bundle. Include variants may differ.
+  if (!include && mapEnvBundleCache) {
+    return mapEnvBundleCache;
+  }
+  if (!include && mapEnvBundlePromise) {
+    return mapEnvBundlePromise;
+  }
+
   const q = include
     ? `?bundle=map-env&include=${encodeURIComponent(include)}`
     : "?bundle=map-env";
-  const res = await fetch(`/api/data${q}`);
-  const json = (await res.json()) as MapEnvApiResponse | { ok: false };
-  if (!res.ok || !("ok" in json) || !json.ok) {
-    throw new Error("Failed to load map environment bundle");
+  const request = fetch(`/api/data${q}`)
+    .then(async (res) => {
+      const json = (await res.json()) as MapEnvApiResponse | { ok: false };
+      if (!res.ok || !("ok" in json) || !json.ok) {
+        throw new Error("Failed to load map environment bundle");
+      }
+      return json.data;
+    })
+    .then((data) => {
+      if (!include) {
+        mapEnvBundleCache = data;
+      }
+      return data;
+    })
+    .finally(() => {
+      if (!include) {
+        mapEnvBundlePromise = null;
+      }
+    });
+
+  if (!include) {
+    mapEnvBundlePromise = request;
   }
-  return json.data;
+
+  return request;
 }
 
 export async function fetchPointEnvironmentalMetrics(

--- a/src/lib/map/layer_manager.ts
+++ b/src/lib/map/layer_manager.ts
@@ -92,10 +92,30 @@ export function addBarangayBounds(map: mapboxgl.Map) {
   }
 }
 
+type LayerSyncState = {
+  layerVisibility: Record<string, boolean>;
+  layerColors: Record<string, string[]>;
+  layerSpecificSelected: Record<string, string>;
+  selectionMode: LocationSelectionMode;
+};
+
 export function addHazardLayers(
   map: mapboxgl.Map,
   layerColors: Record<string, string[]>,
+  getSyncState?: () => LayerSyncState,
 ) {
+  const syncLatestLayerState = () => {
+    const state = getSyncState?.();
+    if (!state) return;
+
+    syncLayerStyles(
+      map,
+      state.layerVisibility,
+      state.layerColors,
+      state.layerSpecificSelected,
+      state.selectionMode,
+    );
+  };
   floodLayersConfig.forEach(({ id, source, sourcelayer, url }) => {
     if (!map.getSource(source)) map.addSource(source, { type: "vector", url });
     if (!map.getLayer(id)) {
@@ -221,6 +241,7 @@ export function addHazardLayers(
             },
             "barangayBoundsOutline",
           );
+          syncLatestLayerState();
         }
       })
       .catch((err) =>
@@ -341,6 +362,7 @@ export function addHazardLayers(
             },
             "barangayBoundsOutline",
           );
+          syncLatestLayerState();
         }
       })
       .catch((err) =>
@@ -368,6 +390,7 @@ export function addHazardLayers(
             },
             "barangayBoundsOutline",
           );
+          syncLatestLayerState();
         }
       })
       .catch((err) =>
@@ -395,6 +418,7 @@ export function addHazardLayers(
             },
             "barangayBoundsOutline",
           );
+          syncLatestLayerState();
         }
       })
       .catch((err) => console.error("Failed to load GI raster tiles:", err));
@@ -582,8 +606,25 @@ export function syncLayerStyles(
     useRaster,
   });
 
-
-
+  // Keep deterministic overlay stacking so LST stays visually above
+  // other environmental overlays regardless of toggle timing.
+  [
+    "aqiFillLayer",
+    "ndviFillLayer",
+    "ndviRasterLayer",
+    "canopyFillLayer",
+    "canopyRasterLayer",
+    "greeneryIndexFillLayer",
+    "giRasterLayer",
+    "lstFillLayer",
+    "lstRasterLayer",
+    "barangayBounds",
+    "barangayBoundsOutline",
+  ].forEach((layerId) => {
+    if (map.getLayer(layerId)) {
+      map.moveLayer(layerId);
+    }
+  });
 
   if (map.getLayer("barangayBounds")) {
     map.setPaintProperty(


### PR DESCRIPTION
## Summary

Implements continuous gradient coloring for the Leaflet choropleth and improves map layer behavior so overlays remain responsive and consistent during style/layer changes. Also updates the legend UI to match the new gradient scale in a compact horizontal format.

## Related Issue

N/A

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build configuration/Scripts

## Key Changes

- **Leaflet coloring:** Replaced categorical choropleth styling with a continuous gradient (`0.0 -> 1.0`) for smoother, location-specific visual transitions.
- **Legend update:** Reworked `GreeneryLegend` to use the exact same gradient function as the map (`getGreeneryColor`) and aligned tick labels to the gradient scale.
- **Mapbox stability:** Prevented full map re-creation on layer/selection changes by keeping a single `mapboxgl.Map` instance and syncing dynamic inputs through refs/effects.
- **Overlay responsiveness:** Added style lifecycle sync hooks (`style.load`, `styledata`, `load`, `idle`) and frame-batched layer sync to avoid stuck toggles when async layers load.
- **Style-switch resilience:** Added client-side map-env bundle caching so overlays rehydrate quickly after style changes instead of appearing reset.
- **Layer ordering:** Standardized overlay z-order so boundaries and hazard/environment layers render consistently.

## How To Test

1. Pull the branch and run `npm install`.
2. Run `npm run dev`.
3. Open the dashboard/landing maps and verify choropleth fills transition smoothly (not hard bucket steps).
4. Toggle hazard/environment layers rapidly and confirm visibility updates remain responsive (no stuck state).
5. Switch map styles and confirm overlays reappear with current toggle state.
6. Verify initial load shows default flood + barangay boundary layers.
7. Check the legend:
   - gradient colors match map fills,
   - labels align with the scale,
   - compact card layout renders correctly in light/dark mode.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough comments, particularly in hard-to-understand areas.
- [x] I have added unit tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
