### PR TITLE
fix: cache mismatch with constants data-pipeline, ensured layers in pin mode generate properly

### DIFF
--- a/src/lib/api/gee_service.ts
+++ b/src/lib/api/gee_service.ts
@@ -219,8 +219,8 @@ function computeCanopyAndGi(combined: any) {
   const ndvi = combined.select("NDVI");
   const lst = combined.select("LST");
 
-  let canopy = ee
-    .Image(0.0)
+  let canopy = (ee.Image(0.0) as any)
+    .updateMask(ndvi.mask())
     .where(ndvi.gt(0.6), 0.8)
     .where(
       ndvi.gt(0.3).and(ndvi.lte(0.6)),
@@ -233,11 +233,18 @@ function computeCanopyAndGi(combined: any) {
     .where(lst.gt(38).and(ndvi.lt(0.4)), canopy.multiply(0.5));
 
   const normLST = lst.subtract(20).divide(20).clamp(0, 1);
-  const greenArea = ee.Image(0.0).where(ndvi.gt(0.2), 1.0);
+  const greenArea = (ee.Image(0.0) as any)
+    .updateMask(ndvi.mask())
+    .where(ndvi.gt(0.2), 1.0);
 
   const gi = ndvi
     .multiply(0.35)
-    .add(ee.Image(1.0).subtract(normLST).multiply(0.25))
+    .add(
+      (ee.Image(1.0) as any)
+        .updateMask(ndvi.mask())
+        .subtract(normLST)
+        .multiply(0.25),
+    )
     .add(canopy.multiply(0.25))
     .add(greenArea.multiply(0.15))
     .clamp(0, 1);

--- a/src/lib/data-pipeline/constants.ts
+++ b/src/lib/data-pipeline/constants.ts
@@ -9,7 +9,7 @@ export const CACHE_TAG_BARANGAYS = "dp-barangays";
 /** Server revalidate windows (seconds) */
 export const REVALIDATE_STATIC_GEO = 86_400; // 24h — local JSON
 export const REVALIDATE_BARANGAY_GEE_BUNDLE = 6 * 3600; // 6h — Sentinel/MODIS stack
-export const REVALIDATE_GEE_TILE_URLS = 4 * 3600; // 4h — map tile templates
+export const REVALIDATE_GEE_TILE_URLS = 1 * 3600; // 1h — map tile templates (GEE tokens expire in ~2h)
 export const REVALIDATE_AQI_LAYER = 3600; // 1h — derived from static merge
 export const REVALIDATE_POINT_METRICS = 3600; // 1h — NASA + GEE point
 export const REVALIDATE_WAQI_POINT = 1200; // 20m — station AQI


### PR DESCRIPTION
## Summary
Layer loading in pin mode was causing 401 errors because of a mismatch in caching, where old URLs were not being removed appropriately as new ones come in 

## Related Issue
N/A 

## Type of Change
- [ ] New feature
- [/] Bug fix
- [ ] Breaking change
- [/] Refactor
- [ ] UI/UX update
- [/] Data or map layer update
- [ ] Database or migration change
- [ ] Documentation or chore

## Scope

- Areas touched: explore map, data-pipeline/constants

## Key Changes
- lowered cache time to 1hr 
- fixed some other layer loading issues 

## Validation

List the checks you actually ran.

- [/] `npm run build`
- [/] `npm run db:validate` (if Prisma or schema changes)
- [/] Manual browser validation
- [/] API route verification
- [ ] Python service verification (if `python-services/timeline_swarm` changed)

### Manual Test Steps

1. Open explore page 
2. Select pin mode
3. Enable any layer that uses GEE, 401 error should be gone 

## Evidence
N/A

## Deployment Notes

- [/] No special deployment steps
- [ ] Requires environment variable changes
- [ ] Requires Prisma migration or database update
- [ ] Requires Supabase policy, storage, or SQL change
- [ ] Requires data file refresh in `public/`

Details:

## Reviewer Notes
N/A

## Checklist Before Review

- [/] I self-reviewed the diff.
- [/] I verified the main affected flow end to end.
- [ ] I updated documentation or inline comments where needed.
- [ ] I included evidence for UI, map, API, or data changes where relevant.
- [ ] I noted any migrations, env changes, or manual setup required.
