### PR TITLE
Improve selection map dragging

### DIFF
--- a/src/components/map/map_wrapper.tsx
+++ b/src/components/map/map_wrapper.tsx
@@ -239,7 +239,7 @@ export default function MapWrapper({
 
             {selectionMode === "custom" ? (
               <p className="w-fit rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-emerald-700 shadow-sm dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300">
-                Drag on the map to draw a freeform area
+                Left-drag to draw. Middle-drag to pan.
               </p>
             ) : null}
           </div>

--- a/src/components/map/mapbox_map.tsx
+++ b/src/components/map/mapbox_map.tsx
@@ -116,6 +116,10 @@ export default function MapboxMap({
     [],
   );
   const customDrawingActiveRef = useRef(false);
+  const customDrawingPointerIdRef = useRef<number | null>(null);
+  const customPanActiveRef = useRef(false);
+  const customPanPointerIdRef = useRef<number | null>(null);
+  const customPanLastPointRef = useRef<{ x: number; y: number } | null>(null);
   const selectionModeRef = useRef(selectionMode);
   const onBarangaySelectedRef = useRef(onBarangaySelected);
   const onMapReadyRef = useRef(onMapReady);
@@ -128,7 +132,6 @@ export default function MapboxMap({
   const handleSelectionRef = useRef<SelectionHandler | null>(null);
 
   const selectedBarangayIdRef = useRef<string | number | undefined>(undefined);
-
   const removeMarker = useCallback(() => {
     if (markerRef.current) {
       markerRef.current.remove();
@@ -262,7 +265,47 @@ export default function MapboxMap({
 
   useEffect(() => {
     selectionModeRef.current = selectionMode;
-  }, [selectionMode]);
+
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (customPanPointerIdRef.current !== null) {
+      try {
+        map.getCanvasContainer().releasePointerCapture(
+          customPanPointerIdRef.current,
+        );
+      } catch {
+        // Ignore release failures if the pointer is no longer captured.
+      }
+    }
+
+    customPanPointerIdRef.current = null;
+    customPanLastPointRef.current = null;
+    customPanActiveRef.current = false;
+
+    if (selectionMode !== "custom") {
+      if (customDrawingPointerIdRef.current !== null) {
+        try {
+          map.getCanvasContainer().releasePointerCapture(
+            customDrawingPointerIdRef.current,
+          );
+        } catch {
+          // Ignore release failures if the pointer is no longer captured.
+        }
+      }
+
+      customDrawingPointerIdRef.current = null;
+      customDrawingActiveRef.current = false;
+      customDrawingPointsRef.current = [];
+      customDrawingScreenPointsRef.current = [];
+      clearDraftCustomAreaOverlay(map);
+      map.dragPan.enable();
+      map.getCanvas().style.cursor = "";
+      return;
+    }
+
+    map.getCanvas().style.cursor = "crosshair";
+  }, [selectionMode, clearDraftCustomAreaOverlay]);
 
   useEffect(() => {
     onBarangaySelectedRef.current = onBarangaySelected;
@@ -377,7 +420,6 @@ export default function MapboxMap({
       );
 
       if (selectionModeRef.current === "custom") {
-        map.dragPan.disable();
         map.getCanvas().style.cursor = "crosshair";
       } else {
         map.dragPan.enable();
@@ -528,7 +570,25 @@ export default function MapboxMap({
     const canvasContainer = map.getCanvasContainer();
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (selectionModeRef.current !== "custom" || event.button !== 0) return;
+      if (event.button === 1) {
+        event.preventDefault();
+        customPanActiveRef.current = true;
+        customPanPointerIdRef.current = event.pointerId;
+        customPanLastPointRef.current = {
+          x: event.clientX,
+          y: event.clientY,
+        };
+        map.getCanvas().style.cursor = "grabbing";
+
+        try {
+          canvasContainer.setPointerCapture(event.pointerId);
+        } catch {}
+
+        return;
+      }
+
+      if (selectionModeRef.current !== "custom") return;
+      if (event.button !== 0) return;
 
       event.preventDefault();
       customDrawingActiveRef.current = true;
@@ -541,6 +601,7 @@ export default function MapboxMap({
         x: event.clientX,
         y: event.clientY,
       });
+      customDrawingPointerIdRef.current = event.pointerId;
 
       ensureCustomSelectionLayers(map);
       syncDraftCustomAreaOverlay(map, customDrawingPointsRef.current);
@@ -553,6 +614,27 @@ export default function MapboxMap({
     };
 
     const handlePointerMove = (event: PointerEvent) => {
+      if (
+        customPanActiveRef.current &&
+        customPanPointerIdRef.current === event.pointerId
+      ) {
+        event.preventDefault();
+
+        const currentPoint = { x: event.clientX, y: event.clientY };
+        const lastPoint = customPanLastPointRef.current;
+
+        if (lastPoint) {
+          map.panBy(
+            [lastPoint.x - currentPoint.x, lastPoint.y - currentPoint.y],
+            { animate: false },
+          );
+        }
+
+        customPanLastPointRef.current = currentPoint;
+        map.getCanvas().style.cursor = "grabbing";
+        return;
+      }
+
       if (selectionModeRef.current !== "custom") return;
 
       map.getCanvas().style.cursor = "crosshair";
@@ -606,6 +688,7 @@ export default function MapboxMap({
       clearDraftCustomAreaOverlay(map);
 
       if (!polygon) {
+        map.dragPan.enable();
         map.getCanvas().style.cursor = "crosshair";
         return;
       }
@@ -646,22 +729,66 @@ export default function MapboxMap({
         false,
       );
 
+      map.dragPan.enable();
       map.getCanvas().style.cursor = "crosshair";
     };
 
     const handlePointerUp = (event: PointerEvent) => {
+      if (
+        customPanActiveRef.current &&
+        customPanPointerIdRef.current === event.pointerId
+      ) {
+        event.preventDefault();
+        customPanActiveRef.current = false;
+        customPanPointerIdRef.current = null;
+        customPanLastPointRef.current = null;
+
+        try {
+          canvasContainer.releasePointerCapture(event.pointerId);
+        } catch {
+          // Ignore release failures when the pointer was not captured.
+        }
+
+        map.getCanvas().style.cursor = "crosshair";
+        return;
+      }
+
       if (selectionModeRef.current !== "custom") return;
 
       void completeCustomSelection(event);
     };
 
     const handlePointerCancel = () => {
+      if (customPanPointerIdRef.current !== null) {
+        try {
+          canvasContainer.releasePointerCapture(customPanPointerIdRef.current);
+        } catch {
+          // Ignore release failures if the pointer is no longer captured.
+        }
+      }
+
+      if (customDrawingPointerIdRef.current !== null) {
+        try {
+          canvasContainer.releasePointerCapture(
+            customDrawingPointerIdRef.current,
+          );
+        } catch {
+          // Ignore release failures if the pointer is no longer captured.
+        }
+      }
+
+      customDrawingPointerIdRef.current = null;
+      customPanPointerIdRef.current = null;
+      customPanLastPointRef.current = null;
+      customDrawingActiveRef.current = false;
+      customPanActiveRef.current = false;
+
       if (selectionModeRef.current !== "custom") return;
 
-      customDrawingActiveRef.current = false;
       customDrawingPointsRef.current = [];
       customDrawingScreenPointsRef.current = [];
       clearDraftCustomAreaOverlay(map);
+      map.dragPan.enable();
       map.getCanvas().style.cursor = "crosshair";
     };
 
@@ -750,9 +877,9 @@ export default function MapboxMap({
 
       if (selectionMode === "custom") {
         mapRef.current.getCanvas().style.cursor = "crosshair";
-        mapRef.current.dragPan.disable();
       } else {
         mapRef.current.dragPan.enable();
+        mapRef.current.getCanvas().style.cursor = "";
       }
     }
   }, [

--- a/src/components/ui/green_solutions/SidebarDiscovery.tsx
+++ b/src/components/ui/green_solutions/SidebarDiscovery.tsx
@@ -90,7 +90,7 @@ export default function SidebarDiscovery({
 
       {locationSelectionMode === "custom" ? (
         <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300">
-          Drag the map to outline a custom lasso area.
+          Left-drag to outline a lasso area. Middle-drag to pan.
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary

This PR improves map interaction while using selection modes. Lasso selection now behaves as a scoped drawing gesture instead of locking navigation, and middle-mouse dragging now pans the map in pin, barangay, and custom selection modes. I also updated the on-screen guidance so the new interaction is discoverable.

## Related Issue

N/A

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] UI/UX update
- [ ] Data or map layer update
- [ ] Database or migration change
- [ ] Documentation or chore

## Scope

- Areas touched: explore map, other
- Barangay, dataset, or feature affected: selection mode interactions for pin, barangay, and custom lasso

## Key Changes

- Allowed middle-mouse dragging to pan the map across all selection modes.
- Kept left-drag behavior for custom lasso selection while preventing it from blocking normal map navigation.
- Updated map and sidebar helper text to explain left-drag versus middle-drag behavior.

## Validation

List the checks you actually ran.

- [ ] `npm run build`
- [ ] `npm run db:validate` (if Prisma or schema changes)
- [ ] Manual browser validation
- [ ] API route verification
- [ ] Python service verification (if `python-services/timeline_swarm` changed)

Focused file-level error checks passed for the edited map and UI files.

### Manual Test Steps

1. Open the explore map.
2. Switch between pin, barangay, and custom selection modes.
3. Hold the middle mouse button and drag to confirm the map pans; in custom mode, left-drag should still draw the lasso.

## Deployment Notes

- [x] No special deployment steps
- [ ] Requires environment variable changes
- [ ] Requires Prisma migration or database update
- [ ] Requires Supabase policy, storage, or SQL change
- [ ] Requires data file refresh in `public/`

Details:

Frontend-only change. No env vars, migrations, or data refreshes are required.

## Reviewer Notes

Middle-button panning depends on browser and device support. Trackpads and devices without a middle mouse button still rely on the existing map interactions.

## Checklist Before Review

- [x] I self-reviewed the diff.
- [ ] I verified the main affected flow end to end.
- [ ] I updated documentation or inline comments where needed.
- [ ] I included evidence for UI, map, API, or data changes where relevant.
- [x] I noted any migrations, env changes, or manual setup required.