### PR TITLE
Fix barangay highlights

### DIFF
--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -242,6 +242,28 @@ export default function ExplorePage() {
 
   const { saves, saveSolution, removeSolution } = useSavedSolutions();
 
+  const clearSelectedBarangayHighlight = useCallback(
+    (barangayName: string | null | undefined) => {
+      if (!barangayName || !mapRef.current) {
+        return;
+      }
+
+      try {
+        mapRef.current.setFeatureState(
+          {
+            source: "barangayBoundsSource",
+            sourceLayer: "mandaue_barangay_boundaries-7byvux",
+            id: barangayName,
+          } as any,
+          { selected: false },
+        );
+      } catch (error) {
+        console.error("Failed to clear barangay highlight:", error);
+      }
+    },
+    [],
+  );
+
   // Build the location payload for SavedTab based on current selection mode
   const savedLocationPayload = useMemo<Omit<
     SavePayload,
@@ -445,6 +467,9 @@ export default function ExplorePage() {
   }, []);
 
   const clearSelection = useCallback(() => {
+    clearSelectedBarangayHighlight(
+      selectedFeature?.barangay ?? activeBarangayData?.name ?? null,
+    );
     setSelectedFeature(null);
     setSelectedBarangay(null);
     setRagRecommendations(null);
@@ -465,7 +490,14 @@ export default function ExplorePage() {
     setGenerateError(null);
     setIsDetailFullscreen(false);
     resetDetailState();
-  }, [imageUrl, resetDetailState, setSelectedBarangay]);
+  }, [
+    activeBarangayData,
+    clearSelectedBarangayHighlight,
+    imageUrl,
+    resetDetailState,
+    selectedFeature,
+    setSelectedBarangay,
+  ]);
 
   const openRecommendationDetail = useCallback(
     (recommendation: UIRecommendation) => {

--- a/src/components/map/map_wrapper.tsx
+++ b/src/components/map/map_wrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { Layers, X, Camera, MapPin, SquareDashed, PenLine } from "lucide-react";
 import HazardLayers from "@/components/map/panels/hazardLayersPanel";
 import MapTypes from "@/components/map/panels/mapTypePanel";
@@ -50,9 +50,11 @@ export default function MapWrapper({
   const [selectedMapType, setSelectedMapType] = useState("Default");
   const effectiveStyleUrl = mapStyles[selectedMapType] ?? mapStyles.Default;
   const [layerColors, setLayerColors] = useState(defaultLayerColors);
-  const [layerVisibility, setLayerVisibility] = useState(
-    defaultLayerVisibility,
-  );
+  const [layerVisibility, setLayerVisibility] = useState(() => ({
+    ...defaultLayerVisibility,
+  }));
+  const [barangayBoundsManualVisible, setBarangayBoundsManualVisible] =
+    useState(defaultLayerVisibility.barangayBoundsLayer);
   const [selectedFloodPeriod, setSelectedFloodPeriod] =
     useState("floodLayer100Yr");
   const [selectedStormAdvisory, setSelectedStormAdvisory] =
@@ -87,15 +89,26 @@ export default function MapWrapper({
 
   const [selectedLegendId, setSelectedLegendId] = useState<string>("");
 
+  const effectiveLayerVisibility = useMemo(
+    () => ({
+      ...layerVisibility,
+      barangayBoundsLayer:
+        selectionMode === "barangay"
+          ? true
+          : barangayBoundsManualVisible,
+    }),
+    [layerVisibility, selectionMode, barangayBoundsManualVisible],
+  );
+
   const activeLegends = useMemo(() => {
     const legends: LegendConfig[] = [];
 
     // Check hazards
-    if (layerVisibility.floodLayer) {
+    if (effectiveLayerVisibility.floodLayer) {
       const leg = getHazardLegend("floodLayer", layerColors.floodLayer);
       if (leg) legends.push(leg);
     }
-    if (layerVisibility.stormLayer) {
+    if (effectiveLayerVisibility.stormLayer) {
       const leg = getHazardLegend("stormLayer", layerColors.stormLayer);
       if (leg) legends.push(leg);
     }
@@ -110,26 +123,29 @@ export default function MapWrapper({
     ] as const;
     envLayers.forEach((id) => {
       if (
-        layerVisibility[id as keyof typeof layerVisibility] &&
+        effectiveLayerVisibility[id as keyof typeof effectiveLayerVisibility] &&
         STATIC_LEGENDS[id]
       ) {
         legends.push(STATIC_LEGENDS[id]);
       }
     });
 
-    if (layerVisibility.taggedTreesLayer && STATIC_LEGENDS.taggedTreesLayer) {
+    if (
+      effectiveLayerVisibility.taggedTreesLayer &&
+      STATIC_LEGENDS.taggedTreesLayer
+    ) {
       legends.push(STATIC_LEGENDS.taggedTreesLayer);
     }
 
     if (
-      layerVisibility.barangayBoundsLayer &&
+      effectiveLayerVisibility.barangayBoundsLayer &&
       STATIC_LEGENDS.barangayBoundsLayer
     ) {
       legends.push(STATIC_LEGENDS.barangayBoundsLayer);
     }
 
     return legends;
-  }, [layerVisibility, layerColors]);
+  }, [effectiveLayerVisibility, layerColors]);
 
   useMemo(() => {
     if (activeLegends.length > 0) {
@@ -147,9 +163,17 @@ export default function MapWrapper({
     [],
   );
 
-  const toggleLayerVisibility = useCallback((layerId: LayerId) => {
-    setLayerVisibility((prev) => ({ ...prev, [layerId]: !prev[layerId] }));
-  }, []);
+  const toggleLayerVisibility = useCallback(
+    (layerId: LayerId) => {
+      if (layerId === "barangayBoundsLayer") {
+        setBarangayBoundsManualVisible((prev) => !prev);
+        return;
+      }
+
+      setLayerVisibility((prev) => ({ ...prev, [layerId]: !prev[layerId] }));
+    },
+    [],
+  );
 
   const changeLayerColor = useCallback((layerId: LayerId, colors: string[]) => {
     setLayerColors((prev) => ({ ...prev, [layerId]: colors }));
@@ -167,7 +191,7 @@ export default function MapWrapper({
     <div className="relative h-full w-screen bg-background font-roboto text-foreground">
       <MapboxMap
         styleUrl={effectiveStyleUrl}
-        layerVisibility={layerVisibility}
+        layerVisibility={effectiveLayerVisibility}
         layerColors={layerColors}
         layerSpecificSelected={layerSpecificSelected}
         searchBoxLocation={searchBoxLocation}
@@ -288,7 +312,7 @@ export default function MapWrapper({
 
           <div className="flex-1 overflow-y-auto space-y-4 p-3 [scrollbar-width:thin] [scrollbar-color:theme(colors.neutral.300)_transparent] dark:[scrollbar-color:theme(colors.neutral.700)_transparent]">
             <HazardLayers
-              layerVisibility={layerVisibility}
+              layerVisibility={effectiveLayerVisibility}
               onToggle={toggleLayerVisibility}
               onColorChange={changeLayerColor}
               selectedFloodPeriod={selectedFloodPeriod}

--- a/src/lib/map/layer_manager.ts
+++ b/src/lib/map/layer_manager.ts
@@ -426,7 +426,6 @@ export function syncLayerStyles(
     map,
     layerVisibility,
     layerColors,
-    selectionMode,
     layerOpacity,
   );
   syncTaggedTreesStyles(map, layerVisibility, layerOpacity);
@@ -598,11 +597,8 @@ function syncBarangayLayerStyles(
   map: mapboxgl.Map,
   layerVisibility: any,
   layerColors: any,
-  selectionMode: string,
   layerOpacity: Record<string, number>,
 ) {
-  const isBarangayMode = selectionMode === "barangay";
-
   const colors = (
     layerColors.barangayBoundsLayer || BARANGAY_CONFIG.defaultColors
   ).map(ensureHex);
@@ -615,6 +611,11 @@ function syncBarangayLayerStyles(
     (layerOpacity && layerOpacity.barangayBoundsLayer) ?? 0.15;
 
   if (map.getLayer(BARANGAY_CONFIG.layers.fill)) {
+    map.setLayoutProperty(
+      BARANGAY_CONFIG.layers.fill,
+      "visibility",
+      layerVisible ? "visible" : "none",
+    );
     map.setPaintProperty(BARANGAY_CONFIG.layers.fill, "fill-color", [
       "case",
       ["boolean", ["feature-state", "selected"], false],
@@ -626,20 +627,25 @@ function syncBarangayLayerStyles(
     map.setPaintProperty(
       BARANGAY_CONFIG.layers.fill,
       "fill-opacity",
-      layerVisible || isBarangayMode
+      layerVisible
         ? [
             "case",
             ["boolean", ["feature-state", "selected"], false],
             Math.min(baseOpacity * 3, 1),
             ["boolean", ["feature-state", "hover"], false],
             Math.min(baseOpacity * 1.6, 1),
-            layerVisible ? baseOpacity : 0.05,
+            baseOpacity,
           ]
         : 0,
     );
   }
 
   if (map.getLayer(BARANGAY_CONFIG.layers.outline)) {
+    map.setLayoutProperty(
+      BARANGAY_CONFIG.layers.outline,
+      "visibility",
+      layerVisible ? "visible" : "none",
+    );
     map.setPaintProperty(BARANGAY_CONFIG.layers.outline, "line-color", [
       "case",
       ["boolean", ["feature-state", "selected"], false],
@@ -651,15 +657,20 @@ function syncBarangayLayerStyles(
     map.setPaintProperty(
       BARANGAY_CONFIG.layers.outline,
       "line-opacity",
-      layerVisible || isBarangayMode ? 1 : 0,
+      layerVisible ? 1 : 0,
     );
   }
 
   if (map.getLayer(BARANGAY_CONFIG.layers.casing)) {
+    map.setLayoutProperty(
+      BARANGAY_CONFIG.layers.casing,
+      "visibility",
+      layerVisible ? "visible" : "none",
+    );
     map.setPaintProperty(
       BARANGAY_CONFIG.layers.casing,
       "line-opacity",
-      layerVisible || isBarangayMode ? 0.4 : 0,
+      layerVisible ? 0.4 : 0,
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes stale barangay highlighting on the explore map and keeps barangay boundaries visible when barangay selection mode is active. Clearing a selection now also resets the underlying Mapbox feature-state, so previously selected barangays do not stay highlighted after the panel is dismissed.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] UI/UX update
- [x] Data or map layer update
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Database or migration change
- [ ] Documentation or chore

## Scope

- Areas touched: explore map, other
- Barangay, dataset, or feature affected: barangay boundary layer and selection highlight state on the explore map

## Key Changes

- Added a helper in the explore page to clear the selected barangay feature-state when the current selection is dismissed.
- Introduced an effective barangay visibility state in the map wrapper so barangay boundaries auto-show in barangay mode but still honor the manual toggle otherwise.
- Simplified barangay layer syncing in the shared layer manager to use the resolved visibility state directly for fill, outline, and casing display.

## Validation

List the checks you actually ran.

- [x] VS Code diagnostics on `src/lib/map/layer_manager.ts`
- [ ] `npm run build`
- [ ] `npm run db:validate` (if Prisma or schema changes)
- [ ] Manual browser validation
- [ ] API route verification
- [ ] Python service verification (if `python-services/timeline_swarm` changed)

### Manual Test Steps

1. Open the explore map.
2. Switch into barangay selection mode and confirm barangay boundaries remain visible.
3. Clear the selection and confirm the prior barangay highlight is removed.

## Evidence

- No screenshots captured in this pass.
- The key behavior change is in the selected barangay feature-state reset and the barangay visibility override in the shared map flow.

## Deployment Notes

- [x] No special deployment steps
- [ ] Requires environment variable changes
- [ ] Requires Prisma migration or database update
- [ ] Requires Supabase policy, storage, or SQL change
- [ ] Requires data file refresh in `public/`

Details:

No deployment changes beyond the code push.

## Reviewer Notes

Focus review on the barangay clear-selection path and the effective visibility logic together. The change relies on Mapbox feature-state for the selected highlight and on the map wrapper to override barangay boundary visibility in barangay mode.

## Checklist Before Review

- [x] I self-reviewed the diff.
- [ ] I verified the main affected flow end to end.
- [ ] I updated documentation or inline comments where needed.
- [x] I included evidence for UI, map, API, or data changes where relevant.
- [x] I noted any migrations, env changes, or manual setup required.