### PR TITLE
chore(ai-chat): make openai primary and gemini as fallback model for …

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,3 +1,5 @@
+import { generateJsonWithFallback } from "@/lib/ai/orchestrator";
+import { AIProviderConfigError } from "@/lib/ai/provider-errors";
 import { NextRequest, NextResponse } from "next/server";
 import {
   buildRAGQuery,
@@ -234,57 +236,26 @@ function selectResponseSources(
   return matchedSources;
 }
 
-// ---------------------------------------------------------------------------
-// Gemini Call (adapted from lib/ai/gemini.ts)
-// ---------------------------------------------------------------------------
+type AssistantModelResponse = {
+  reply?: string;
+  mode?: "grounded" | "general";
+  citedSources?: string[];
+};
 
-async function callGemini(systemPrompt: string, userPrompt: string) {
-  const apiKey = process.env.GEMINI_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("Missing GEMINI_API_KEY");
+function parseAssistantModelResponse(rawText: string): AssistantModelResponse {
+  try {
+    return JSON.parse(rawText) as AssistantModelResponse;
+  } catch {
+    console.warn(
+      "AI provider returned non-JSON response. Using raw text as reply.",
+    );
+
+    return {
+      reply: rawText,
+      mode: "general",
+      citedSources: [],
+    };
   }
-
-  const model = process.env.GEMINI_MODEL?.trim() || "gemini-2.0-flash";
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-goog-api-key": apiKey,
-    },
-    body: JSON.stringify({
-      systemInstruction: {
-        parts: [{ text: systemPrompt }],
-      },
-      contents: [
-        {
-          role: "user",
-          parts: [{ text: userPrompt }],
-        },
-      ],
-      generationConfig: {
-        temperature: 0.4,
-        topP: 0.9,
-        maxOutputTokens: 1024,
-        responseMimeType: "application/json",
-      },
-    }),
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error?.message || `Gemini API error: ${response.status}`);
-  }
-
-  const data = await response.json();
-  const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (!text) {
-    throw new Error("Gemini returned an empty response.");
-  }
-
-  return text;
 }
 
 // ---------------------------------------------------------------------------
@@ -374,20 +345,21 @@ ${formatSources(chunks)}
 ## Conversation
 ${payload.messages.map((message) => `${message.role.toUpperCase()}: ${message.content}`).join("\n")}`;
 
-    const rawText = await callGemini(systemPrompt, userPrompt);
-    
-    let parsed: {
-      reply?: string;
-      mode?: "grounded" | "general";
-      citedSources?: string[];
-    };
-    
-    try {
-      parsed = JSON.parse(rawText);
-    } catch {
-      console.warn("Gemini returned non-JSON; falling back to raw text as reply.");
-      parsed = { reply: rawText, mode: "general", citedSources: [] };
-    }
+    const aiResult = await generateJsonWithFallback({
+      feature: "chat",
+      systemPrompt,
+      userPrompt,
+      temperature: 0.4,
+      topP: 0.9,
+      maxOutputTokens: 1024,
+      parse: parseAssistantModelResponse,
+    });
+
+    const parsed = aiResult.value;
+
+    console.info(
+      `Assistant chat completed via ${aiResult.provider} (${aiResult.model}).`,
+    );
 
     const replyText =
       parsed.reply?.trim() ||
@@ -395,32 +367,34 @@ ${payload.messages.map((message) => `${message.role.toUpperCase()}: ${message.co
     const mode = parsed.mode === "grounded" ? "grounded" : "general";
     const availableSources = dedupeSources(chunks);
 
-    // Return the response. 
-    // The UI (ChatTab.tsx) expects { reply, error? }.
-    // We include sources and mode for compatibility and future use.
-    return NextResponse.json({
-      reply: replyText,
-      mode,
-      sources: selectResponseSources(
-        availableSources,
-        parsed.citedSources,
-        replyText,
+    return NextResponse.json(
+      {
+        reply: replyText,
         mode,
-      ),
-      query: ragQuery,
-    });
+        sources: selectResponseSources(
+          availableSources,
+          parsed.citedSources,
+          replyText,
+          mode,
+        ),
+        query: ragQuery,
+      },
+      { status: 200 },
+    );
   } catch (error) {
     console.error("Assistant chat failed:", error);
-    
-    const isMissingApiKey =
-      error instanceof Error && error.message === "Missing GEMINI_API_KEY";
+
+    const isMissingProviderConfig = error instanceof AIProviderConfigError;
 
     return NextResponse.json(
-      { 
-        reply: isMissingApiKey
-          ? "AI chat is not configured yet. Set GEMINI_API_KEY on the server to enable the GreenPoint assistant."
+      {
+        reply: isMissingProviderConfig
+          ? "AI chat is not configured yet. Set OPENAI_API_KEY for the primary provider and GEMINI_API_KEY for fallback support."
           : "I’m having trouble responding right now. Please try again in a moment.",
-        error: error instanceof Error ? error.message : "Failed to generate assistant reply." 
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to generate assistant reply.",
       },
       { status: 500 },
     );

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,0 +1,86 @@
+import type { AIFeatureName, AIProviderName } from "./types";
+
+const DEFAULT_PRIMARY_PROVIDER: AIProviderName = "openai";
+const DEFAULT_FALLBACK_PROVIDER: AIProviderName = "gemini";
+
+const DEFAULT_MODELS: Record<AIProviderName, Record<AIFeatureName, string>> = {
+    openai: {
+        chat: "gpt-4o-mini",
+        recommendations: "gpt-4o-mini",
+        simulationNarrative: "gpt-4o-mini",
+        visionAnalysis: "gpt-4o-mini",
+    },
+    gemini: {
+        chat: "gemini-2.0-flash",
+        recommendations: "gemini-2.0-flash",
+        simulationNarrative: "gemini-2.0-flash",
+        visionAnalysis: "gemini-2.0-flash",
+    }
+}
+
+const FEATURE_MODEL_ENV_KEYS: Record<
+    AIFeatureName,
+    Record<AIProviderName, string>
+> = {
+    chat: {
+        openai: "OPENAI_CHAT_MODEL",
+        gemini: "GEMINI_CHAT_MODEL",
+    },
+    recommendations: {
+        openai: "OPENAI_RECOMMENDATIONS_MODEL",
+        gemini: "GEMINI_RECOMMENDATIONS_MODEL",
+    },
+    simulationNarrative: {
+        openai: "OPENAI_SIMULATION_MODEL",
+        gemini: "GEMINI_SIMULATION_MODEL",
+    },
+    visionAnalysis: {
+        openai: "OPENAI_VISION_MODEL",
+        gemini: "GEMINI_VISION_MODEL",
+    }
+}
+
+function normalizeProvider(
+    value: string | undefined,
+    fallback: AIProviderName,
+): AIProviderName {
+    if (value === "openai" || value === "gemini") {
+        return value;
+    }
+
+    return fallback;
+}
+
+export function getPrimaryProvider(): AIProviderName {
+    return normalizeProvider(
+        process.env.AI_PRIMARY_PROVIDER?.trim(),
+        DEFAULT_PRIMARY_PROVIDER,
+    );
+}
+
+export function getFallbackProvider(): AIProviderName | null {
+    const primary = getPrimaryProvider();
+    const fallback = normalizeProvider(
+        process.env.AI_FALLBACK_PROVIDER?.trim(),
+        DEFAULT_FALLBACK_PROVIDER,
+    );
+
+    return fallback === primary ? null : fallback;
+}
+
+export function getProviderOrder(): AIProviderName[] {
+    const primary = getPrimaryProvider();
+    const fallback = getFallbackProvider();
+
+    return fallback ? [primary, fallback] : [primary];
+}
+
+export function getModelForFeature(
+    provider: AIProviderName,
+    feature: AIFeatureName,
+): string {
+    const envKey = FEATURE_MODEL_ENV_KEYS[feature][provider];
+    const configuredModel = process.env[envKey]?.trim();
+
+    return configuredModel || DEFAULT_MODELS[provider][feature];
+}

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -1,24 +1,12 @@
 import "server-only";
 
+import { getModelForFeature } from "./config";
 import {
-  DEFAULT_CHATBOT_SYSTEM_PROMPT,
-  normalizeSystemPromptOverride,
-} from "@/lib/ai/chat-prompt";
-import type { ChatApiMessage, ChatRequestPayload } from "@/types/chat";
-
-const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
-const DEFAULT_FALLBACK_MODELS = ["gemini-2.0-flash-lite", "gemini-2.0-flash"];
-const GEMINI_MODEL = process.env.GEMINI_MODEL?.trim() || DEFAULT_GEMINI_MODEL;
-const GEMINI_MODELS = [
-  GEMINI_MODEL,
-  ...(process.env.GEMINI_FALLBACK_MODELS
-    ?.split(",")
-    .map((model) => model.trim())
-    .filter(Boolean) ?? DEFAULT_FALLBACK_MODELS),
-].filter((model, index, models) => models.indexOf(model) === index);
-const RETRYABLE_GEMINI_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
-
-type GeminiRole = "user" | "model";
+  AIProviderConfigError,
+  AIProviderRequestError,
+  createProviderRequestError,
+} from "./provider-errors";
+import type { AIJsonTextRequest, AIProviderTextResult } from "./types";
 
 interface GeminiGenerateContentResponse {
   candidates?: Array<{
@@ -36,109 +24,18 @@ interface GeminiGenerateContentResponse {
   };
 }
 
-interface GeminiRequestErrorDetails {
-  status: number;
-  message: string;
-}
+function getGeminiApiKey() {
+  const apiKey = process.env.GEMINI_API_KEY?.trim();
 
-class GeminiRequestError extends Error {
-  readonly status: number;
-
-  constructor({ status, message }: GeminiRequestErrorDetails) {
-    super(message);
-    this.name = "GeminiRequestError";
-    this.status = status;
-  }
-}
-
-function formatNumber(value: number | null | undefined, digits = 2) {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value.toFixed(digits)
-    : "N/A";
-}
-
-function formatList(values: number[] | undefined) {
-  if (!values?.length) return "N/A";
-  return values.map((value) => formatNumber(value)).join(", ");
-}
-
-function buildSystemInstruction(payload: ChatRequestPayload) {
-  const {
-    recommendation,
-    selectedFeature,
-    selectedBarangayData,
-    systemPromptOverride,
-  } = payload;
-
-  const contextLines = [
-    normalizeSystemPromptOverride(systemPromptOverride) ||
-      DEFAULT_CHATBOT_SYSTEM_PROMPT,
-    "",
-    "Project context:",
-    `- Recommendation title: ${recommendation.title}`,
-    `- Recommendation description: ${recommendation.description}`,
-    `- Intervention type: ${recommendation.interventionType || "N/A"}`,
-    `- Efficiency level: ${recommendation.efficiencyLevel || "N/A"}`,
-    `- Efficiency score: ${formatNumber(recommendation.efficiencyScore)}`,
-    `- Equity index: ${formatNumber(recommendation.equityIndex)}`,
-    `- Cost index: ${formatNumber(recommendation.costIndex)}`,
-    `- Impact score: ${formatNumber(recommendation.impactScore)}`,
-    `- Estimated cost: ${formatNumber(recommendation.estimatedCost)} ${recommendation.costUnit || ""}`.trim(),
-    `- Selected place: ${selectedFeature.name}`,
-    `- Address: ${selectedFeature.address}`,
-    `- Barangay: ${selectedFeature.barangay || selectedBarangayData?.name || "N/A"}`,
-    `- Custom area size (hectares): ${formatNumber(selectedFeature.customSelectionAreaHectares)}`,
-    `- Coordinates: ${formatNumber(selectedFeature.coords.lat, 6)}, ${formatNumber(selectedFeature.coords.lng, 6)}`,
-    `- Flood hazard levels: ${formatList(selectedFeature.hazardSummary?.floodLevels)}`,
-    `- Storm hazard levels: ${formatList(selectedFeature.hazardSummary?.stormLevels)}`,
-    `- Air quality observations available: ${selectedFeature.hazardSummary?.airQualityCount ?? 0}`,
-  ];
-
-  if (selectedBarangayData) {
-    contextLines.push(
-      `- Barangay greenery index: ${formatNumber(selectedBarangayData.greeneryIndex)}`,
-      `- Barangay NDVI: ${formatNumber(selectedBarangayData.ndvi)}`,
-      `- Barangay land surface temperature: ${formatNumber(selectedBarangayData.lst)}`,
-      `- Barangay tree canopy: ${formatNumber(selectedBarangayData.treeCanopy)}`,
-      `- Barangay flood exposure: ${selectedBarangayData.floodExposure}`,
-      `- Current intervention: ${selectedBarangayData.currentIntervention}`,
-    );
+  if (!apiKey) {
+    throw new AIProviderConfigError("gemini", "Missing GEMINI_API_KEY");
   }
 
-  return contextLines.join("\n");
+  return apiKey;
 }
 
-function normalizeMessages(messages: ChatApiMessage[]) {
-  const cleaned = messages
-    .map((message) => ({
-      role: message.role,
-      content: message.content.trim(),
-    }))
-    .filter((message) => message.content.length > 0);
-
-  const merged: ChatApiMessage[] = [];
-  for (const message of cleaned) {
-    const previous = merged[merged.length - 1];
-    if (previous && previous.role === message.role) {
-      previous.content = `${previous.content}\n\n${message.content}`;
-      continue;
-    }
-
-    merged.push(message);
-  }
-
-  while (merged[0]?.role === "assistant") {
-    merged.shift();
-  }
-
-  return merged;
-}
-
-function toGeminiContents(messages: ChatApiMessage[]) {
-  return normalizeMessages(messages).map((message) => ({
-    role: (message.role === "assistant" ? "model" : "user") as GeminiRole,
-    parts: [{ text: message.content }],
-  }));
+function buildGeminiApiUrl(model: string) {
+  return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 }
 
 function extractReply(data: GeminiGenerateContentResponse) {
@@ -150,12 +47,8 @@ function extractReply(data: GeminiGenerateContentResponse) {
   );
 }
 
-function buildGeminiApiUrl(model: string) {
-  return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
-}
-
-function isRetryableGeminiError(status: number, message: string) {
-  if (RETRYABLE_GEMINI_STATUS_CODES.has(status)) {
+function isRetryableGeminiFailure(status: number, message: string) {
+  if ([429, 500, 502, 503, 504].includes(status)) {
     return true;
   }
 
@@ -164,96 +57,91 @@ function isRetryableGeminiError(status: number, message: string) {
   );
 }
 
-function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+export async function generateJsonWithGemini(
+  request: AIJsonTextRequest,
+): Promise<AIProviderTextResult> {
+  const apiKey = getGeminiApiKey();
+  const model = getModelForFeature("gemini", request.feature);
 
-async function requestGeminiReply(
-  model: string,
-  apiKey: string,
-  payload: ChatRequestPayload,
-  contents: ReturnType<typeof toGeminiContents>,
-) {
-  const response = await fetch(buildGeminiApiUrl(model), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-goog-api-key": apiKey,
-    },
-    body: JSON.stringify({
-      systemInstruction: {
-        parts: [{ text: buildSystemInstruction(payload) }],
+  try {
+    const response = await fetch(buildGeminiApiUrl(model), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": apiKey,
       },
-      contents,
-      generationConfig: {
-        temperature: 0.4,
-        topP: 0.9,
-        maxOutputTokens: 700,
-      },
-    }),
-    cache: "no-store",
-    signal: AbortSignal.timeout(30000),
-  });
-
-  const data = (await response.json()) as GeminiGenerateContentResponse;
-
-  if (!response.ok) {
-    throw new GeminiRequestError({
-      status: response.status,
-      message: data.error?.message || `Gemini request failed with ${response.status}`,
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [{ text: request.systemPrompt }],
+        },
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: request.userPrompt }],
+          },
+        ],
+        generationConfig: {
+          temperature: request.temperature ?? 0.4,
+          topP: request.topP ?? 0.9,
+          maxOutputTokens: request.maxOutputTokens ?? 1024,
+          responseMimeType: "application/json",
+        },
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(30000),
     });
-  }
 
-  if (data.promptFeedback?.blockReason) {
-    throw new Error(`Gemini blocked the prompt: ${data.promptFeedback.blockReason}`);
-  }
+    const data = (await response.json()) as GeminiGenerateContentResponse;
 
-  const reply = extractReply(data);
-  if (!reply) {
-    throw new Error("Gemini returned an empty reply");
-  }
+    if (!response.ok) {
+      const message =
+        data.error?.message || `Gemini request failed with ${response.status}`;
 
-  return reply;
-}
-
-export async function generateChatReply(payload: ChatRequestPayload) {
-  const apiKey = process.env.GEMINI_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error("Missing GEMINI_API_KEY");
-  }
-
-  const contents = toGeminiContents(payload.messages);
-  if (!contents.length) {
-    throw new Error("Chat history must include at least one user message");
-  }
-
-  let lastError: Error | null = null;
-
-  for (let modelIndex = 0; modelIndex < GEMINI_MODELS.length; modelIndex += 1) {
-    const model = GEMINI_MODELS[modelIndex];
-
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        return await requestGeminiReply(model, apiKey, payload, contents);
-      } catch (error) {
-        if (!(error instanceof GeminiRequestError)) {
-          throw error;
-        }
-
-        lastError = error;
-
-        const shouldRetry = isRetryableGeminiError(error.status, error.message);
-        const hasAnotherAttemptForModel = attempt === 0;
-        const hasAnotherModel = modelIndex < GEMINI_MODELS.length - 1;
-
-        if (!shouldRetry || (!hasAnotherAttemptForModel && !hasAnotherModel)) {
-          throw error;
-        }
-
-        await wait(600 * (attempt + 1));
-      }
+      throw new AIProviderRequestError({
+        provider: "gemini",
+        message,
+        status: response.status,
+        retryable: isRetryableGeminiFailure(response.status, message),
+      });
     }
-  }
 
-  throw lastError ?? new Error("Gemini request failed");
+    if (data.promptFeedback?.blockReason) {
+      throw new AIProviderRequestError({
+        provider: "gemini",
+        message: `Gemini blocked the prompt: ${data.promptFeedback.blockReason}`,
+        status: 400,
+        retryable: false,
+      });
+    }
+
+    const rawText = extractReply(data);
+
+    if (!rawText) {
+      throw new AIProviderRequestError({
+        provider: "gemini",
+        message: "Gemini returned an empty response.",
+        status: null,
+        retryable: false,
+      });
+    }
+
+    return {
+      provider: "gemini",
+      model,
+      rawText,
+    };
+  } catch (error) {
+    if (
+      error instanceof AIProviderConfigError ||
+      error instanceof AIProviderRequestError
+    ) {
+      throw error;
+    }
+
+    throw createProviderRequestError(
+      "gemini",
+      error,
+      "Gemini request failed.",
+    );
+  }
 }

--- a/src/lib/ai/openai.ts
+++ b/src/lib/ai/openai.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import OpenAI from "openai";
+import { getModelForFeature } from "./config";
+import {
+  AIProviderConfigError,
+  AIProviderRequestError,
+  createProviderRequestError,
+} from "./provider-errors";
+import type { AIJsonTextRequest, AIProviderTextResult } from "./types";
+
+function getOpenAIApiKey() {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new AIProviderConfigError("openai", "Missing OPENAI_API_KEY");
+  }
+
+  return apiKey;
+}
+
+export async function generateJsonWithOpenAI(
+  request: AIJsonTextRequest,
+): Promise<AIProviderTextResult> {
+  const apiKey = getOpenAIApiKey();
+  const model = getModelForFeature("openai", request.feature);
+
+  try {
+    const client = new OpenAI({ apiKey });
+
+    const completion = await client.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: request.systemPrompt },
+        { role: "user", content: request.userPrompt },
+      ],
+      response_format: { type: "json_object" },
+      temperature: request.temperature ?? 0.4,
+      top_p: request.topP ?? 0.9,
+      max_tokens: request.maxOutputTokens ?? 1024,
+    });
+
+    const rawText = completion.choices[0]?.message?.content?.trim() ?? "";
+
+    if (!rawText) {
+      throw new AIProviderRequestError({
+        provider: "openai",
+        message: "OpenAI returned an empty response.",
+        status: null,
+        retryable: false,
+      });
+    }
+
+    return {
+      provider: "openai",
+      model,
+      rawText,
+    };
+  } catch (error) {
+    if (
+      error instanceof AIProviderConfigError ||
+      error instanceof AIProviderRequestError
+    ) {
+      throw error;
+    }
+
+    throw createProviderRequestError(
+      "openai",
+      error,
+      "OpenAI request failed.",
+    );
+  }
+}

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { getProviderOrder } from "./config";
+import { generateJsonWithGemini } from "./gemini";
+import { generateJsonWithOpenAI } from "./openai";
+import { isRetryableProviderFailure } from "./provider-errors";
+import type {
+  AIJsonTextRequest,
+  AIProviderName,
+  AIProviderTextResult,
+} from "./types";
+
+export interface AIJsonFallbackRequest<T> extends AIJsonTextRequest {
+    parse: (rawText: string) => T;
+}
+
+export interface AIJsonFallbackResponse<T> extends AIProviderTextResult {
+  value: T;
+}
+
+const JSON_GENERATORS: Record<
+    AIProviderName,
+    (request: AIJsonTextRequest) => Promise<AIProviderTextResult>
+> = {
+    openai: generateJsonWithOpenAI,
+    gemini: generateJsonWithGemini,
+};
+
+export async function generateJsonWithFallback<T>(
+    request: AIJsonFallbackRequest<T>,
+): Promise<AIJsonFallbackResponse<T>> {
+    const providerOrder = getProviderOrder();
+    let lastError: unknown = null;
+
+    for (let index = 0; index < providerOrder.length; index += 1) {
+    const provider = providerOrder[index];
+
+    try {
+      const result = await JSON_GENERATORS[provider](request);
+
+      return {
+        ...result,
+        value: request.parse(result.rawText),
+      };
+    } catch (error) {
+      lastError = error;
+
+      const hasAnotherProvider = index < providerOrder.length - 1;
+      if (!hasAnotherProvider || !isRetryableProviderFailure(error)) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("All AI providers failed.");
+}

--- a/src/lib/ai/provider-errors.ts
+++ b/src/lib/ai/provider-errors.ts
@@ -1,0 +1,83 @@
+import type { AIProviderName } from "./types";
+
+interface AIProviderRequestErrorInit {
+    provider: AIProviderName;
+    message: string;
+    status: number | null;
+    retryable: boolean;
+}
+
+export class AIProviderConfigError extends Error {
+    readonly provider: AIProviderName;
+
+    constructor(provider: AIProviderName, message: string) {
+        super(message);
+        this.name = "AIProviderConfigError";
+        this.provider = provider;
+    }
+}
+
+export class AIProviderRequestError extends Error {
+    readonly provider: AIProviderName;
+    readonly status: number | null;
+    readonly retryable: boolean;
+
+    constructor({
+        provider,
+        message,
+        status,
+        retryable,
+    }: AIProviderRequestErrorInit) {
+        super(message);
+        this.name = "AIProviderRequestError";
+        this.provider = provider;
+        this.status = status;
+        this.retryable = retryable;
+    }
+}
+
+export function createProviderRequestError(
+    provider: AIProviderName,
+    error: unknown,
+    fallbackMessage: string,
+): AIProviderRequestError {
+    const maybeStatus = 
+        typeof error === "object" &&
+        error !== null && 
+        "status" in error
+            ? (error as { status?: unknown }).status
+            : null;
+
+    const status = typeof maybeStatus === "number" ? maybeStatus : null;
+
+    const message =
+        error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : fallbackMessage;
+
+    const retryable =
+    status !== null
+      ? [429, 500, 502, 503, 504].includes(status)
+      : /timeout|temporar|overloaded|unavailable|rate limit|network|fetch failed/i.test(
+          message,
+        );
+
+    return new AIProviderRequestError({
+        provider,
+        message,
+        status,
+        retryable,
+    });
+}
+
+export function isRetryableProviderFailure(error: unknown) {
+    if (error instanceof AIProviderConfigError) {
+        return true;
+    }
+
+    if (error instanceof AIProviderRequestError) {
+        return error.retryable;
+    }
+
+    return false;
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,22 @@
+export type AIProviderName = "openai" | "gemini";
+
+export type AIFeatureName = 
+    | "chat"
+    | "recommendations"
+    | "simulationNarrative"
+    | "visionAnalysis";
+
+export interface AIJsonTextRequest {
+    feature: AIFeatureName;
+    systemPrompt: string;
+    userPrompt: string;
+    temperature?: number;
+    topP?: number;
+    maxOutputTokens?: number;
+}
+
+export interface AIProviderTextResult {
+    provider: AIProviderName;
+    model: string;
+    rawText: string;
+}


### PR DESCRIPTION
## Summary

This PR refactors the chat assistant to use a centralized AI orchestration layer instead of hardcoding a single provider inside the chat route. Chat now resolves providers through shared config and adapter modules, with OpenAI positioned as the primary provider path and Gemini available as fallback infrastructure. The chat API response contract remains unchanged for the UI, and the route compile/control-flow errors introduced during the refactor were corrected.

## Related Issue

N/A

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [X] Refactor
- [ ] UI/UX update
- [ ] Data or map layer update
- [ ] Database or migration change
- [ ] Documentation or chore

## Scope

- Areas touched: API routes, other
- Barangay, dataset, or feature affected: Green Solutions chat assistant / `/api/chat`

## Key Changes

- Added shared AI provider scaffolding for chat: provider types, config, error handling, OpenAI adapter, Gemini adapter, and fallback orchestrator.
- Refactored `/api/chat` to call the shared orchestrator instead of using an inline Gemini-only implementation.
- Restored the chat route success/error control flow after the refactor so the route compiles and returns the expected response shape again.

## Validation

List the checks you actually ran.

- [ ] `npm run build`
- [ ] `npm run db:validate` (if Prisma or schema changes)
- [ ] Manual browser validation
- [ ] API route verification
- [ ] Python service verification (if `python-services/timeline_swarm` changed)

### Manual Test Steps

1. Configure `AI_PRIMARY_PROVIDER`, `AI_FALLBACK_PROVIDER`, `OPENAI_API_KEY`, and optionally `GEMINI_API_KEY`.
2. Open the Green Solutions chat flow and send a message that hits `/api/chat`.
3. Confirm the assistant responds normally and the route still returns `reply`, `mode`, `sources`, and `query` without UI regression.

## Evidence

No UI screenshots or API captures were added in this pass. Validation completed so far was focused on compile diagnostics: the updated chat route reports no file-level errors after the control-flow fix.

## Deployment Notes

- [ ] No special deployment steps
- [X] Requires environment variable changes
- [ ] Requires Prisma migration or database update
- [ ] Requires Supabase policy, storage, or SQL change
- [ ] Requires data file refresh in `public/`

Details:

Add or document the following environment variables for chat provider routing:
- `AI_PRIMARY_PROVIDER`
- `AI_FALLBACK_PROVIDER`
- `OPENAI_API_KEY`
- `OPENAI_CHAT_MODEL`
- `GEMINI_API_KEY`
- `GEMINI_CHAT_MODEL`


## Reviewer Notes

This PR only migrates the chat route to the shared provider layer. Recommendations, simulation narrative, vision analysis, and embeddings still use their existing provider-specific paths and should be migrated in follow-up work. Embeddings were intentionally left untouched to avoid vector compatibility and retrieval-quality regressions.

## Checklist Before Review

- [ ] I self-reviewed the diff.
- [ ] I verified the main affected flow end to end.
- [ ] I updated documentation or inline comments where needed.
- [ ] I included evidence for UI, map, API, or data changes where relevant.
- [X] I noted any migrations, env changes, or manual setup required.
