### PR TITLE
Chore/timeline fixes

### DIFF
--- a/src/app/(app)/explore/components/ExploreGeneratingOverlay.tsx
+++ b/src/app/(app)/explore/components/ExploreGeneratingOverlay.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { Sprout } from "lucide-react";
+import { useState, useCallback, useEffect, type MutableRefObject } from "react";
+import { Sprout, Camera, Check } from "lucide-react";
 
 interface ExploreGeneratingOverlayProps {
   isGenerating: boolean;
   generatingStep: string | null;
+  onUploadRequested?: () => void;
+  /** Ref that page.tsx calls after a file is actually accepted. */
+  uploadAcceptedRef?: MutableRefObject<(() => void) | null>;
 }
 
 /**
@@ -13,7 +17,26 @@ interface ExploreGeneratingOverlayProps {
 export default function ExploreGeneratingOverlay({
   isGenerating,
   generatingStep,
+  onUploadRequested,
+  uploadAcceptedRef,
 }: ExploreGeneratingOverlayProps) {
+  const [uploadFeedback, setUploadFeedback] = useState<"idle" | "received">("idle");
+
+  /* ── Expose a function page.tsx calls when a file is actually accepted ── */
+  useEffect(() => {
+    if (!uploadAcceptedRef) return;
+    uploadAcceptedRef.current = () => {
+      setUploadFeedback("received");
+      setTimeout(() => setUploadFeedback("idle"), 4000);
+    };
+    return () => {
+      uploadAcceptedRef.current = null;
+    };
+  }, [uploadAcceptedRef]);
+
+  const handleUploadClick = useCallback(() => {
+    onUploadRequested?.();
+  }, [onUploadRequested]);
   if (!isGenerating) return null;
 
   return (
@@ -42,6 +65,33 @@ export default function ExploreGeneratingOverlay({
           <span className="h-1.5 w-1.5 rounded-full bg-primary-green animate-pulse delay-150" />
           <span className="h-1.5 w-1.5 rounded-full bg-primary-green animate-pulse delay-300" />
         </div>
+
+        {onUploadRequested && (
+          <>
+            <div className="w-full max-w-[8rem] h-px bg-neutral-100 dark:bg-neutral-800" />
+            <button
+              type="button"
+              onClick={handleUploadClick}
+              className={`flex items-center justify-center gap-2.5 rounded-2xl border px-5 py-2.5 text-sm font-bold shadow-sm transition-all hover:scale-[1.02] active:scale-[0.98] ${
+                uploadFeedback === "received"
+                  ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400"
+                  : "border-neutral-200 bg-white text-primary-green hover:border-primary-green/40 hover:bg-primary-green/5 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:border-primary-green/40"
+              }`}
+            >
+              {uploadFeedback === "received" ? (
+                <>
+                  <Check size={18} />
+                  <span>Photo received!</span>
+                </>
+              ) : (
+                <>
+                  <Camera size={18} />
+                  <span>Upload a photo</span>
+                </>
+              )}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/app/(app)/explore/hooks/useVisionContext.ts
+++ b/src/app/(app)/explore/hooks/useVisionContext.ts
@@ -17,6 +17,7 @@ export function useVisionContext() {
     string | null
   >(null);
   const [isVisionAnalyzing, setIsVisionAnalyzing] = useState(false);
+  const [visionProgress, setVisionProgress] = useState<string | null>(null);
   const [showWarning, setShowWarning] = useState<
     "no-gps" | "out-of-bounds" | null
   >(null);
@@ -42,6 +43,7 @@ export function useVisionContext() {
     setVisionTags([]);
     setVisionStatusMessage(null);
     setIsVisionAnalyzing(false);
+    setVisionProgress(null);
     setShowWarning(null);
   }, [imageUrl]);
 
@@ -56,6 +58,8 @@ export function useVisionContext() {
     setVisionStatusMessage,
     isVisionAnalyzing,
     setIsVisionAnalyzing,
+    visionProgress,
+    setVisionProgress,
     showWarning,
     setShowWarning,
     fileInputRef,

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -16,6 +16,8 @@ import type { SelectedFeature } from "@/types/metrics";
 import {
   POINT_SELECTION_AREA_HECTARES,
 } from "@/lib/selection-area";
+import { fetchMapEnvBundle } from "@/lib/data-api/client";
+import * as turf from "@turf/turf";
 import { toast } from "sonner";
 import type { VisionContext } from "@/lib/vision/context";
 import SideBar from "@/components/explore/SideBar";
@@ -249,6 +251,8 @@ export default function ExplorePage() {
         pointSelectionAreaHectares: POINT_SELECTION_AREA_HECTARES,
         isLoadingMetrics: true,
       });
+      setBottomExpanded(true);
+      setIsSidebarOpen(true);
 
       setVisionProgress("Navigating to photo location…");
 
@@ -348,7 +352,7 @@ export default function ExplorePage() {
                   inventoryCanopyFraction:
                     (pointMetrics.inventoryCanopyFraction as number) ?? 0,
                 },
-                isLoadingMetrics: false,
+      isLoadingMetrics: false,
               }
             : null,
         );
@@ -422,6 +426,8 @@ export default function ExplorePage() {
       setVisionStatusMessage,
       setIsVisionAnalyzing,
       setVisionProgress,
+      setBottomExpanded,
+      setIsSidebarOpen,
     ],
   );
 
@@ -604,6 +610,22 @@ export default function ExplorePage() {
     setVisionStatusMessage(null);
     setVisionProgress("Extracting GPS from photo…");
 
+    /* ── Immediately switch sidebar to photo mode (before async GPS read) ── */
+    clearRecommendationsState();
+    setSelectedFeature({
+      name: "Photo Location",
+      address: "Extracting GPS from photo…",
+      coords: { lng: 0, lat: 0 },
+      barangay: "",
+      isLoadingMetrics: false,
+    });
+    setBottomExpanded(true);
+    setIsSidebarOpen(true);
+    setIsVisionAnalyzing(true);
+
+    /* ── Yield to React so sidebar opens before any async work ── */
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     /* ── Notify overlay that file was actually accepted ── */
     uploadAcceptedRef.current?.();
     /* ── Confirm upload accepted (critical during overlay, helpful always) ── */
@@ -612,44 +634,58 @@ export default function ExplorePage() {
     try {
       const gps = await exifr.gps(file);
 
+      /* ── User cancelled (X button) while GPS was loading? ── */
+      if (!photoModeRef.current) return;
+
       /* ── No GPS? Let the user tap the map to set the location ── */
       if (!gps?.latitude || !gps?.longitude) {
         pendingManualPinRef.current = { file, url };
         setIsAwaitingManualPin(true);
         setLocationSelectionMode("poi");
         setVisionProgress(null);
-        clearRecommendationsState();
-        /* Show sidebar with photo preview + "Tap on map" prompt */
-        setSelectedFeature({
-          name: "Photo Location",
-          address: "Tap on the map to place this photo",
-          coords: { lng: 0, lat: 0 },
-          barangay: "",
-          isLoadingMetrics: false,
-        });
+        /* Update placeholder address — photo preview already showing */
+        setSelectedFeature((prev) =>
+          prev?.name === "Photo Location"
+            ? { ...prev, address: "Tap on the map to place this photo" }
+            : prev,
+        );
         return;
       }
 
-      /* ── User cancelled (X button) while GPS was loading? ── */
-      if (!photoModeRef.current) return;
-
-      setIsVisionAnalyzing(true);
-
       const { latitude: lat, longitude: lng } = gps;
-      const point = mapRef.current.project([lng, lat]);
-      const features = mapRef.current.queryRenderedFeatures(point, {
-        layers: ["barangayBounds"],
-      });
-      const barangay = features[0]?.properties?.name;
+
+      /* ── Resolve barangay via turf point-in-polygon (doesn't depend on map layers) ── */
+      let barangay = "";
+      try {
+        const bundle = await fetchMapEnvBundle();
+        const features = bundle.barangayGeoJson.greeneryIndex.features ?? [];
+        const pt = turf.point([lng, lat]);
+        const matched = features.find((f) => {
+          if (!f.geometry) return false;
+          if (
+            f.geometry.type !== "Polygon" &&
+            f.geometry.type !== "MultiPolygon"
+          )
+            return false;
+          try {
+            return turf.booleanPointInPolygon(
+              pt,
+              f as GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>,
+            );
+          } catch {
+            return false;
+          }
+        });
+        barangay = matched?.properties?.name ?? "";
+      } catch (err) {
+        console.error("Error resolving photo barangay:", err);
+      }
 
       if (!barangay) {
         setShowWarning("out-of-bounds");
         clearSelection();
         return;
       }
-
-      /* ── Switch to the photo location immediately ── */
-      clearRecommendationsState();
 
       await continuePhotoUpload(lat, lng, barangay, file);
     } catch (err) {
@@ -661,14 +697,11 @@ export default function ExplorePage() {
         pendingManualPinRef.current = { file, url };
         setIsAwaitingManualPin(true);
         setLocationSelectionMode("poi");
-        clearRecommendationsState();
-        setSelectedFeature({
-          name: "Photo Location",
-          address: "Tap on the map to place this photo",
-          coords: { lng: 0, lat: 0 },
-          barangay: "",
-          isLoadingMetrics: false,
-        });
+        setSelectedFeature((prev) =>
+          prev?.name === "Photo Location"
+            ? { ...prev, address: "Tap on the map to place this photo" }
+            : prev,
+        );
       }
     }
   };

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -100,6 +100,9 @@ export default function ExplorePage() {
   /* ── Ref for overlay to expose upload-accepted callback ── */
   const uploadAcceptedRef = useRef<(() => void) | null>(null);
 
+  /* ── Guards stale feature_selection callbacks from overwriting a photo upload ── */
+  const photoModeRef = useRef(false);
+
   const {
     imageUrl,
     setImageUrl,
@@ -187,6 +190,7 @@ export default function ExplorePage() {
   // ── Orchestration callbacks ──────────────────────────────────────────────
 
   const clearSelection = useCallback(() => {
+    photoModeRef.current = false;
     clearSelectedBarangayHighlight(
       selectedFeature?.barangay ?? activeBarangayData?.name ?? null,
     );
@@ -234,6 +238,7 @@ export default function ExplorePage() {
   const continuePhotoUpload = useCallback(
     async (lat: number, lng: number, barangay: string, file: File) => {
       if (!mapRef.current) return;
+      if (!photoModeRef.current) return; // cancelled while loading
 
       /* ── Set feature immediately with skeleton ── */
       setSelectedFeature({
@@ -406,6 +411,7 @@ export default function ExplorePage() {
       /* ── Done analyzing ── */
       setIsVisionAnalyzing(false);
       setVisionProgress(null);
+      photoModeRef.current = false;
     },
     [
       setSelectedFeature,
@@ -530,6 +536,9 @@ export default function ExplorePage() {
         // Malformed feature — fall through to normal selection
       }
 
+      /* ── Gate: All stale feature_selection callbacks during photo upload ── */
+      if (photoModeRef.current) return;
+
       setSelectedFeature(feature);
       setRagRecommendations(null);
       setSelectedRecommendation(null);
@@ -585,6 +594,9 @@ export default function ExplorePage() {
     /* ── Reset file input so re-uploading the same image works ── */
     e.target.value = "";
 
+    /* ── Mark photo mode so stale selection callbacks don't overwrite ── */
+    photoModeRef.current = true;
+
     const url = URL.createObjectURL(file);
     setImageUrl(url);
     setVisionContext(null);
@@ -618,6 +630,9 @@ export default function ExplorePage() {
         return;
       }
 
+      /* ── User cancelled (X button) while GPS was loading? ── */
+      if (!photoModeRef.current) return;
+
       setIsVisionAnalyzing(true);
 
       const { latitude: lat, longitude: lng } = gps;
@@ -639,6 +654,8 @@ export default function ExplorePage() {
       await continuePhotoUpload(lat, lng, barangay, file);
     } catch (err) {
       console.error("EXIF Error:", err);
+      /* ── User cancelled while GPS was loading? ── */
+      if (!photoModeRef.current) return;
       /* Couldn't read EXIF at all — let user place pin manually */
       if (!pendingManualPinRef.current) {
         pendingManualPinRef.current = { file, url };

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -3,6 +3,8 @@
 import {
   useEffect,
   useCallback,
+  useRef,
+  useState,
   Suspense,
 } from "react";
 import dynamic from "next/dynamic";
@@ -91,6 +93,13 @@ export default function ExplorePage() {
 
   const { trackLocationMetrics } = useMetricsTracking();
 
+  /* ── No-GPS photo → manual pin placement ── */
+  const pendingManualPinRef = useRef<{ file: File; url: string } | null>(null);
+  const [isAwaitingManualPin, setIsAwaitingManualPin] = useState(false);
+
+  /* ── Ref for overlay to expose upload-accepted callback ── */
+  const uploadAcceptedRef = useRef<(() => void) | null>(null);
+
   const {
     imageUrl,
     setImageUrl,
@@ -102,6 +111,8 @@ export default function ExplorePage() {
     setVisionStatusMessage,
     isVisionAnalyzing,
     setIsVisionAnalyzing,
+    visionProgress,
+    setVisionProgress,
     showWarning,
     setShowWarning,
     fileInputRef,
@@ -183,6 +194,8 @@ export default function ExplorePage() {
     setSelectedBarangay(null);
     setRagRecommendations(null);
     clearVisionState();
+    pendingManualPinRef.current = null;
+    setIsAwaitingManualPin(false);
     if (markerRef.current) {
       markerRef.current.remove();
       markerRef.current = null;
@@ -212,52 +225,197 @@ export default function ExplorePage() {
     setBottomExpanded,
     setIsSidebarOpen,
     setSelectedFeature,
+    setIsAwaitingManualPin,
   ]);
 
-  const handleFeatureSelected = useCallback(
-    (feature: SelectedFeature) => {
-      setSelectedFeature(feature);
-      setRagRecommendations(null);
-      setSelectedRecommendation(null);
-      setActiveView("LIST");
-      resetDetailState();
-      setVisionContext(null);
-      setVisionTags([]);
-      setVisionStatusMessage(null);
-      setIsVisionAnalyzing(false);
+  /* ── Shared: continue photo upload with validated coordinates ── */
+  /*     Called from handleFileUploaded (GPS found) OR from                  */
+  /*     handleFeatureSelected (manual pin after no-GPS).                   */
+  const continuePhotoUpload = useCallback(
+    async (lat: number, lng: number, barangay: string, file: File) => {
+      if (!mapRef.current) return;
 
-      if (
-        !feature.isLoadingMetrics &&
-        (feature.barangay || feature.properties)
-      ) {
-        const props = feature.properties;
-        void trackLocationMetrics(
-          feature.pointID ? "POINT" : feature.barangay ? "BARANGAY" : "CUSTOM",
-          feature.barangay || feature.name,
-          {
-            ndvi: props?.ndvi,
-            lst: props?.temperature || props?.lst,
-            treeCanopy: props?.treeCanopy,
-            greeneryIndex: props?.greeneryIndex,
-            greeneryLevel: props?.level,
-            aqi: feature.hazards?.air?.[0]?.AQI_Level,
-          },
-          feature.pointID || null,
-          feature.coords,
+      /* ── Set feature immediately with skeleton ── */
+      setSelectedFeature({
+        name: "Photo Location",
+        address: "Detected Photo Location",
+        coords: { lng, lat },
+        barangay,
+        pointSelectionAreaHectares: POINT_SELECTION_AREA_HECTARES,
+        isLoadingMetrics: true,
+      });
+
+      setVisionProgress("Navigating to photo location…");
+
+      mapRef.current.flyTo({
+        center: [lng, lat],
+        zoom: 16,
+        speed: 1.2,
+        essential: true,
+      });
+
+      if (markerRef.current) markerRef.current.remove();
+      const newMarker = new mapboxgl.Marker({ color: "#DB4848" })
+        .setLngLat([lng, lat])
+        .addTo(mapRef.current);
+      markerRef.current = newMarker;
+
+      /* ── Geocode in background for a proper address ── */
+      let address = "Detected Photo Location";
+      try {
+        const geocodeRes = await fetch(
+          `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${mapboxgl.accessToken}`,
+        );
+        const geocodeData = await geocodeRes.json();
+        address =
+          geocodeData.features?.[0]?.place_name || "Detected Photo Location";
+      } catch { /* non-fatal */ }
+
+      setSelectedFeature((prev) =>
+        prev ? { ...prev, address } : null,
+      );
+
+      setVisionProgress("Fetching environmental data & running vision analysis…");
+
+      /* ── Fire point-metrics + vision in parallel ── */
+      const [pointMetrics, visionResult] = await Promise.all([
+        (async () => {
+          try {
+            const mRes = await fetch(
+              `/api/data?resource=point&lat=${lat}&lng=${lng}`,
+            );
+            const mObj = await mRes.json();
+            if (mObj.ok && mObj.data?.success && mObj.data.metrics) {
+              return mObj.data.metrics as Record<string, unknown>;
+            }
+          } catch { /* non-fatal */ }
+          return null;
+        })(),
+        (async () => {
+          try {
+            const formData = new FormData();
+            formData.append("image", file);
+            formData.append("lat", String(lat));
+            formData.append("lng", String(lng));
+            formData.append("barangay", String(barangay));
+            const visionRes = await fetch("/api/geophotos/analyze", {
+              method: "POST",
+              body: formData,
+            });
+            return (await visionRes.json()) as {
+              success?: boolean;
+              data?: {
+                visionContext?: VisionContext | null;
+                analysisError?: string | null;
+                quickTags?: string[];
+                analysisSource?: "cache" | "openai";
+              };
+              error?: string;
+            };
+          } catch (error) {
+            console.error("Geo-photo analysis failed:", error);
+            return null;
+          }
+        })(),
+      ]);
+
+      setVisionProgress("Processing results…");
+
+      /* ── Update feature with real point-level metrics ── */
+      if (pointMetrics) {
+        setSelectedFeature((prev) =>
+          prev
+            ? {
+                ...prev,
+                properties: {
+                  ...prev.properties,
+                  ndvi: (pointMetrics.ndvi as number) ?? prev.properties?.ndvi,
+                  temperature:
+                    (pointMetrics.lst as number) ?? prev.properties?.temperature,
+                  treeCanopy:
+                    (pointMetrics.treeCanopy as number) ??
+                    prev.properties?.treeCanopy,
+                  greeneryIndex:
+                    (pointMetrics.greeneryIndex as number) ??
+                    prev.properties?.greeneryIndex,
+                  nearbyTaggedTreeCount:
+                    (pointMetrics.nearbyTaggedTreeCount as number) ?? 0,
+                  inventoryCanopyFraction:
+                    (pointMetrics.inventoryCanopyFraction as number) ?? 0,
+                },
+                isLoadingMetrics: false,
+              }
+            : null,
+        );
+      } else {
+        setSelectedFeature((prev) =>
+          prev ? { ...prev, isLoadingMetrics: false } : null,
         );
       }
+
+      /* ── Apply vision result ── */
+      if (visionResult) {
+        if (visionResult.success) {
+          setVisionContext(visionResult.data?.visionContext ?? null);
+          setVisionTags(visionResult.data?.quickTags ?? []);
+          if (!visionResult.data?.visionContext) {
+            setVisionStatusMessage(
+              visionResult.data?.analysisError ??
+                "Vision analysis was unavailable for this image.",
+            );
+          } else if (visionResult.data.visionContext.confidence < 0.35) {
+            setVisionStatusMessage(
+              `Vision confidence too low (${Math.round(
+                visionResult.data.visionContext.confidence * 100,
+              )}%). Falling back to metric-based recommendations.`,
+            );
+          } else {
+            setVisionStatusMessage(
+              visionResult.data.analysisSource === "cache"
+                ? "Loaded cached image analysis from a previous upload."
+                : null,
+            );
+          }
+          if (visionResult.data?.analysisError) {
+            toast.warning(
+              "Image uploaded but vision extraction had low confidence. Using metric-only recommendations.",
+            );
+          }
+        } else {
+          setVisionContext(null);
+          setVisionTags([]);
+          setVisionStatusMessage(
+            visionResult.error ??
+              "Vision analysis request failed. Continuing with metric-based recommendations.",
+          );
+          toast.warning(
+            "Photo uploaded but vision analysis was unavailable. Continuing with metric-based recommendations.",
+          );
+        }
+      } else {
+        setVisionContext(null);
+        setVisionTags([]);
+        setVisionStatusMessage(
+          "Vision analysis request failed. Continuing with metric-based recommendations.",
+        );
+        toast.warning(
+          "Photo uploaded but vision analysis was unavailable. Continuing with metric-based recommendations.",
+        );
+      }
+
+      /* ── Done analyzing ── */
+      setIsVisionAnalyzing(false);
+      setVisionProgress(null);
     },
     [
-      trackLocationMetrics,
-      resetDetailState,
-      setSelectedRecommendation,
-      setRagRecommendations,
+      setSelectedFeature,
+      markerRef,
+      mapRef,
       setVisionContext,
       setVisionTags,
       setVisionStatusMessage,
       setIsVisionAnalyzing,
-      setActiveView,
-      setSelectedFeature,
+      setVisionProgress,
     ],
   );
 
@@ -333,24 +491,134 @@ export default function ExplorePage() {
     setActiveView,
   ]);
 
+  /* ── Helper: clear old recommendations / detail state when switching to a photo ── */
+  const clearRecommendationsState = useCallback(() => {
+    setRagRecommendations(null);
+    resetDetailState();
+    setActiveView("LIST");
+    setSelectedRecommendation(null);
+    setGenerateError(null);
+  }, [
+    setRagRecommendations,
+    resetDetailState,
+    setActiveView,
+    setSelectedRecommendation,
+    setGenerateError,
+  ]);
+
+  const handleFeatureSelected = useCallback(
+    (feature: SelectedFeature) => {
+      /* ── Intercept: manual pin after no-GPS photo upload ── */
+      if (pendingManualPinRef.current) {
+        const pending = pendingManualPinRef.current;
+        pendingManualPinRef.current = null;
+        setIsAwaitingManualPin(false);
+
+        const coords = feature.coords;
+        const barangay = feature.barangay || "";
+        if (coords?.lat && coords?.lng && barangay) {
+          clearRecommendationsState();
+          setIsVisionAnalyzing(true);
+          void continuePhotoUpload(
+            coords.lat,
+            coords.lng,
+            barangay,
+            pending.file,
+          );
+          return;
+        }
+        // Malformed feature — fall through to normal selection
+      }
+
+      setSelectedFeature(feature);
+      setRagRecommendations(null);
+      setSelectedRecommendation(null);
+      setActiveView("LIST");
+      resetDetailState();
+      setVisionContext(null);
+      setVisionTags([]);
+      setVisionStatusMessage(null);
+      setIsVisionAnalyzing(false);
+
+      if (
+        !feature.isLoadingMetrics &&
+        (feature.barangay || feature.properties)
+      ) {
+        const props = feature.properties;
+        void trackLocationMetrics(
+          feature.pointID ? "POINT" : feature.barangay ? "BARANGAY" : "CUSTOM",
+          feature.barangay || feature.name,
+          {
+            ndvi: props?.ndvi,
+            lst: props?.temperature || props?.lst,
+            treeCanopy: props?.treeCanopy,
+            greeneryIndex: props?.greeneryIndex,
+            greeneryLevel: props?.level,
+            aqi: feature.hazards?.air?.[0]?.AQI_Level,
+          },
+          feature.pointID || null,
+          feature.coords,
+        );
+      }
+    },
+    [
+      trackLocationMetrics,
+      resetDetailState,
+      clearRecommendationsState,
+      setSelectedRecommendation,
+      setRagRecommendations,
+      setVisionContext,
+      setVisionTags,
+      setVisionStatusMessage,
+      setIsVisionAnalyzing,
+      setActiveView,
+      setSelectedFeature,
+      continuePhotoUpload,
+      setIsAwaitingManualPin,
+    ],
+  );
+
   const handleFileUploaded = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !mapRef.current) return;
+
+    /* ── Reset file input so re-uploading the same image works ── */
+    e.target.value = "";
 
     const url = URL.createObjectURL(file);
     setImageUrl(url);
     setVisionContext(null);
     setVisionTags([]);
     setVisionStatusMessage(null);
-    setIsVisionAnalyzing(true);
+    setVisionProgress("Extracting GPS from photo…");
+
+    /* ── Notify overlay that file was actually accepted ── */
+    uploadAcceptedRef.current?.();
+    /* ── Confirm upload accepted (critical during overlay, helpful always) ── */
+    toast.success("Photo received — switching to photo location.");
 
     try {
       const gps = await exifr.gps(file);
+
+      /* ── No GPS? Let the user tap the map to set the location ── */
       if (!gps?.latitude || !gps?.longitude) {
-        setShowWarning("no-gps");
-        setIsVisionAnalyzing(false);
+        pendingManualPinRef.current = { file, url };
+        setIsAwaitingManualPin(true);
+        setLocationSelectionMode("poi");
+        setVisionProgress(null);
+        clearRecommendationsState();
+        /* Show sidebar with photo preview + "Tap on map" prompt */
+        setSelectedFeature({
+          name: "Photo Location",
+          address: "Tap on the map to place this photo",
+          coords: { lng: 0, lat: 0 },
+          barangay: "",
+          isLoadingMetrics: false,
+        });
         return;
       }
+
+      setIsVisionAnalyzing(true);
 
       const { latitude: lat, longitude: lng } = gps;
       const point = mapRef.current.project([lng, lat]);
@@ -362,114 +630,29 @@ export default function ExplorePage() {
       if (!barangay) {
         setShowWarning("out-of-bounds");
         clearSelection();
-        setIsVisionAnalyzing(false);
         return;
       }
 
-      mapRef.current.flyTo({
-        center: [lng, lat],
-        zoom: 16,
-        speed: 1.2,
-        essential: true,
-      });
+      /* ── Switch to the photo location immediately ── */
+      clearRecommendationsState();
 
-      if (markerRef.current) markerRef.current.remove();
-      const newMarker = new mapboxgl.Marker({ color: "#DB4848" })
-        .setLngLat([lng, lat])
-        .addTo(mapRef.current);
-      markerRef.current = newMarker;
-
-      const res = await fetch(
-        `https://api.mapbox.com/geocoding/v5/mapbox.places/${lng},${lat}.json?access_token=${mapboxgl.accessToken}`,
-      );
-      const data = await res.json();
-      const address =
-        data.features?.[0]?.place_name || "Detected Photo Location";
-
-      setSelectedFeature({
-        name: "Photo Location",
-        address,
-        coords: { lng, lat },
-        barangay,
-        pointSelectionAreaHectares: POINT_SELECTION_AREA_HECTARES,
-      });
-
-      try {
-        const formData = new FormData();
-        formData.append("image", file);
-        formData.append("lat", String(lat));
-        formData.append("lng", String(lng));
-        formData.append("barangay", String(barangay));
-        const visionRes = await fetch("/api/geophotos/analyze", {
-          method: "POST",
-          body: formData,
-        });
-        const visionJson = (await visionRes.json()) as {
-          success?: boolean;
-          data?: {
-            visionContext?: VisionContext | null;
-            analysisError?: string | null;
-            quickTags?: string[];
-            analysisSource?: "cache" | "openai";
-          };
-          error?: string;
-        };
-        if (visionJson.success) {
-          setVisionContext(visionJson.data?.visionContext ?? null);
-          setVisionTags(visionJson.data?.quickTags ?? []);
-          if (!visionJson.data?.visionContext) {
-            setVisionStatusMessage(
-              visionJson.data?.analysisError ??
-                "Vision analysis was unavailable for this image.",
-            );
-          } else if (visionJson.data.visionContext.confidence < 0.35) {
-            setVisionStatusMessage(
-              `Vision confidence too low (${Math.round(
-                visionJson.data.visionContext.confidence * 100,
-              )}%). Falling back to metric-based recommendations.`,
-            );
-          } else {
-            setVisionStatusMessage(
-              visionJson.data.analysisSource === "cache"
-                ? "Loaded cached image analysis from a previous upload."
-                : null,
-            );
-          }
-          if (visionJson.data?.analysisError) {
-            toast.warning(
-              "Image uploaded but vision extraction had low confidence. Using metric-only recommendations.",
-            );
-          }
-        } else {
-          setVisionContext(null);
-          setVisionTags([]);
-          setVisionStatusMessage(
-            visionJson.error ??
-              "Vision analysis request failed. Continuing with metric-based recommendations.",
-          );
-          toast.warning(
-            "Photo uploaded but vision analysis was unavailable. Continuing with metric-based recommendations.",
-          );
-        }
-      } catch (error) {
-        console.error("Geo-photo analysis failed:", error);
-        setVisionContext(null);
-        setVisionTags([]);
-        setVisionStatusMessage(
-          error instanceof Error
-            ? error.message
-            : "Vision analysis failed. Continuing with metric-based recommendations.",
-        );
-        toast.warning(
-          "Vision analysis failed. Continuing with metric-based recommendations.",
-        );
-      } finally {
-        setIsVisionAnalyzing(false);
-      }
+      await continuePhotoUpload(lat, lng, barangay, file);
     } catch (err) {
       console.error("EXIF Error:", err);
-      setShowWarning("no-gps");
-      setIsVisionAnalyzing(false);
+      /* Couldn't read EXIF at all — let user place pin manually */
+      if (!pendingManualPinRef.current) {
+        pendingManualPinRef.current = { file, url };
+        setIsAwaitingManualPin(true);
+        setLocationSelectionMode("poi");
+        clearRecommendationsState();
+        setSelectedFeature({
+          name: "Photo Location",
+          address: "Tap on the map to place this photo",
+          coords: { lng: 0, lat: 0 },
+          barangay: "",
+          isLoadingMetrics: false,
+        });
+      }
     }
   };
 
@@ -560,6 +743,8 @@ export default function ExplorePage() {
             imageUrl,
             hasUsableContext: hasUsableVisionContext,
             statusMessage: visionStatusMessage,
+            isAwaitingManualPin,
+            progress: visionProgress,
           }}
           generation={{
             ragRecommendations,
@@ -586,6 +771,8 @@ export default function ExplorePage() {
         <ExploreGeneratingOverlay
           isGenerating={isGenerating}
           generatingStep={generatingStep}
+          onUploadRequested={() => fileInputRef.current?.click()}
+          uploadAcceptedRef={uploadAcceptedRef}
         />
 
         <ExploreWarningModal

--- a/src/components/explore/ExploreDesktopListInterventions.tsx
+++ b/src/components/explore/ExploreDesktopListInterventions.tsx
@@ -17,6 +17,7 @@ export default function ExploreDesktopListInterventions({
   visionContext,
   visionTags,
   isVisionAnalyzing,
+  visionProgress,
   imageUrl,
   selectedFeature,
   clearSelection,
@@ -42,6 +43,7 @@ export default function ExploreDesktopListInterventions({
   selectedFeature: SelectedFeature | null;
   clearSelection: () => void;
   hasUsableVisionContext: boolean;
+  visionProgress?: string | null;
   visionStatusMessage: string | null;
   ragRecommendations: UIRecommendation[] | null;
   generateError: string | null;
@@ -94,7 +96,7 @@ export default function ExploreDesktopListInterventions({
           {isVisionAnalyzing ? (
             <div className="mt-1 flex items-center gap-2 text-xs font-semibold text-primary-green dark:text-primary-green/80">
               <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary-green/30 border-t-primary-green" />
-              <span>Analyzing uploaded image...</span>
+              <span>{visionProgress || "Analyzing uploaded image…"}</span>
             </div>
           ) : (
             <p className="mt-1 text-xs font-medium text-neutral-600 dark:text-neutral-300">

--- a/src/components/explore/SideBar.tsx
+++ b/src/components/explore/SideBar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React, { type Dispatch, type SetStateAction } from "react";
-import { MapPin, X } from "lucide-react";
-import { createPortal } from "react-dom";
+import { MapPin, X, ImageIcon } from "lucide-react";
+
 import type { SelectedFeature } from "@/types/metrics";
 import type { BarangayData } from "@/context/BarangayContext";
 import type {
@@ -53,6 +53,8 @@ export interface SideBarProps {
     imageUrl: string | null;
     hasUsableContext: boolean;
     statusMessage: string | null;
+    isAwaitingManualPin?: boolean;
+    progress?: string | null;
   };
   generation: {
     ragRecommendations: UIRecommendation[] | null;
@@ -118,6 +120,8 @@ export default function SideBar({
     imageUrl,
     hasUsableContext: hasUsableVisionContext,
     statusMessage: visionStatusMessage,
+    isAwaitingManualPin,
+    progress: visionProgress,
   } = vision;
   const {
     ragRecommendations,
@@ -146,41 +150,85 @@ export default function SideBar({
           s.locationName === savedLocationPayload?.locationName),
     );
 
-  const portalContent =
-    isDetailFullscreen && selectedRecommendation && selectedFeature ? (
-      <div
-        className="hidden lg:flex fixed inset-0 z-[120] bg-neutral-900/45 backdrop-blur-sm p-6"
-        onClick={() => setIsDetailFullscreen(false)}
-      >
+
+
+  const isFullscreenExpanded = isDetailFullscreen && activeView === "DETAIL";
+  const isLoadingMetrics = selectedFeature?.isLoadingMetrics;
+
+  return (
+    <>
+      {/* Backdrop when fullscreen — click to exit */}
+      {isFullscreenExpanded && (
         <div
-          className="mx-auto flex h-full w-full max-w-[1440px] overflow-hidden rounded-[2rem] border border-white/50 bg-white/95 shadow-2xl dark:border-neutral-800 dark:bg-neutral-950/95 dark:shadow-black/40"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <div className="flex w-full h-full flex-col overflow-hidden">
-            <div className="flex items-center justify-between border-b border-neutral-100 bg-white/70 p-6 backdrop-blur-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-              <div className="flex items-center gap-4 min-w-0">
-                <div className="shrink-0 rounded-2xl bg-primary-green/10 p-3.5 text-primary-green shadow-inner dark:bg-primary-green/20 dark:text-primary-green/80">
-                  <MapPin size={28} />
+          className="fixed inset-0 z-40 hidden bg-neutral-900/45 backdrop-blur-sm lg:block"
+          onClick={() => setIsDetailFullscreen(false)}
+        />
+      )}
+
+      <div
+        className={`fixed bottom-0 left-0 right-0 z-50 transition-all duration-500 ease-out 
+          lg:absolute lg:top-8 lg:bottom-8 lg:left-24 lg:z-20 lg:w-[min(28rem,calc(100vw-5.5rem))] lg:flex lg:flex-col
+          ${
+            isFullscreenExpanded
+              ? "lg:fixed lg:inset-2 lg:z-[120] lg:w-auto lg:max-w-[1600px] lg:mx-auto"
+              : ""
+          }
+          ${
+            bottomExpanded
+              ? "translate-y-0"
+              : "translate-y-full lg:translate-y-0"
+          }
+          ${
+            isSidebarOpen || isFullscreenExpanded
+              ? "lg:translate-x-0 lg:opacity-100"
+              : "lg:-translate-x-full lg:opacity-0 lg:pointer-events-none"
+          }
+        `}
+      >
+        <div className="flex h-[85vh] lg:h-full w-full flex-col overflow-hidden rounded-t-[2.5rem] lg:rounded-[2rem] border-t lg:border border-white/50 bg-white/95 lg:bg-white/90 shadow-[0_-8px_30px_rgba(0,0,0,0.12)] lg:shadow-[0_8px_30px_rgb(0,0,0,0.08)] backdrop-blur-2xl lg:backdrop-blur-xl dark:border-neutral-800 dark:bg-neutral-950/95 dark:shadow-black/50">
+          <div className="mx-auto mt-4 h-1.5 w-12 shrink-0 rounded-full bg-neutral-200 dark:bg-neutral-800 lg:hidden" />
+
+          {/* Hide outer header when fullscreen DETAIL — SidebarDetail has its own */}
+          {isFullscreenExpanded ? null : (
+            <div className="shrink-0 flex items-center justify-between border-b border-neutral-100 px-4 py-3 lg:px-6 lg:py-4 dark:border-neutral-800">
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="shrink-0 rounded-xl bg-primary-green/10 p-2.5 text-primary-green dark:bg-primary-green/20 dark:text-primary-green/80">
+                  <MapPin size={20} />
                 </div>
                 <div className="min-w-0">
-                  <h4 className="text-lg font-bold leading-tight text-neutral-900 dark:text-neutral-50">
-                    {selectedFeature.name || "Target Area"}
+                  <h4 className="truncate font-bold text-neutral-900 dark:text-neutral-50">
+                    {selectedFeature
+                      ? selectedFeature.name
+                      : "No Location Selected"}
                   </h4>
-                  <p className="mt-0.5 text-xs font-bold text-neutral-500 opacity-70 dark:text-neutral-400">
-                    {selectedFeature.address || "Analyzing location..."}
-                  </p>
+                  {selectedFeature && (
+                    <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
+                      {selectedFeature.address}
+                    </p>
+                  )}
                 </div>
               </div>
-
-              <button
-                onClick={clearSelection}
-                className="rounded-full p-2.5 text-neutral-400 transition-all hover:rotate-90 hover:bg-neutral-100 hover:text-red-500 dark:text-neutral-500 dark:hover:bg-neutral-800"
-              >
-                <X size={24} />
-              </button>
+              {selectedFeature && (
+                <button
+                  onClick={clearSelection}
+                  className="shrink-0 rounded-full p-2 text-neutral-400 transition-all hover:rotate-90 hover:bg-neutral-100 hover:text-red-500 dark:text-neutral-500 dark:hover:bg-neutral-800"
+                >
+                  <X size={20} />
+                </button>
+              )}
             </div>
+          )}
 
-            <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+          <div
+            className={`scrollbar-hide flex-1 p-4 lg:p-6 lg:pt-0 ${
+              activeView === "DETAIL"
+                ? "flex flex-col min-h-0 overflow-hidden"
+                : "overflow-y-auto"
+            }`}
+          >
+            {activeView === "DETAIL" &&
+            selectedRecommendation &&
+            selectedFeature ? (
               <SidebarDetail
                 recommendation={selectedRecommendation}
                 selectedFeature={selectedFeature}
@@ -196,117 +244,93 @@ export default function SideBar({
                 onChatLoadingChange={setIsDetailChatLoading}
                 timelineViewMode={detailTimelineView}
                 onTimelineViewModeChange={setDetailTimelineView}
-                isFullscreen
-                onToggleFullscreen={() => setIsDetailFullscreen(false)}
                 isSaved={isSaved(selectedRecommendation)}
                 onToggleSave={
                   savedLocationPayload
                     ? (e) => handleToggleSave(e, selectedRecommendation)
                     : undefined
                 }
+                isFullscreen={isFullscreenExpanded}
+                onToggleFullscreen={
+                  isFullscreenExpanded
+                    ? () => setIsDetailFullscreen(false)
+                    : () => setIsDetailFullscreen(true)
+                }
               />
-            </div>
-          </div>
-        </div>
-      </div>
-    ) : null;
-
-  return (
-    <>
-      <div
-        className={`fixed bottom-0 left-0 right-0 z-50 transition-all duration-500 ease-out 
-          lg:absolute lg:top-8 lg:bottom-8 lg:left-24 lg:z-20 lg:w-[min(28rem,calc(100vw-5.5rem))] lg:flex lg:flex-col
-          ${
-            bottomExpanded
-              ? "translate-y-0"
-              : "translate-y-full lg:translate-y-0"
-          }
-          ${
-            isSidebarOpen && !(isDetailFullscreen && activeView === "DETAIL")
-              ? "lg:translate-x-0 lg:opacity-100"
-              : "lg:-translate-x-full lg:opacity-0 lg:pointer-events-none"
-          }
-        `}
-      >
-        <div className="flex h-[85vh] lg:h-full w-full flex-col overflow-hidden rounded-t-[2.5rem] lg:rounded-[2rem] border-t lg:border border-white/50 bg-white/95 lg:bg-white/90 shadow-[0_-8px_30px_rgba(0,0,0,0.12)] lg:shadow-[0_8px_30px_rgb(0,0,0,0.08)] backdrop-blur-2xl lg:backdrop-blur-xl dark:border-neutral-800 dark:bg-neutral-950/95 dark:shadow-black/50">
-          <div className="mx-auto mt-4 h-1.5 w-12 shrink-0 rounded-full bg-neutral-200 dark:bg-neutral-800 lg:hidden" />
-
-          <div className="shrink-0 flex items-center justify-between border-b border-neutral-100 px-4 py-3 lg:px-6 lg:py-4 dark:border-neutral-800">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="shrink-0 rounded-xl bg-primary-green/10 p-2.5 text-primary-green dark:bg-primary-green/20 dark:text-primary-green/80">
-                <MapPin size={20} />
-              </div>
-              <div className="min-w-0">
-                <h4 className="truncate font-bold text-neutral-900 dark:text-neutral-50">
-                  {selectedFeature
-                    ? selectedFeature.name
-                    : "No Location Selected"}
-                </h4>
-                {selectedFeature && (
-                  <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
-                    {selectedFeature.address}
-                  </p>
-                )}
-              </div>
-            </div>
-            {selectedFeature && (
-              <button
-                onClick={clearSelection}
-                className="shrink-0 rounded-full p-2 text-neutral-400 transition-all hover:rotate-90 hover:bg-neutral-100 hover:text-red-500 dark:text-neutral-500 dark:hover:bg-neutral-800"
-              >
-                <X size={20} />
-              </button>
-            )}
-          </div>
-
-          <div
-            className={`scrollbar-hide flex-1 p-4 lg:p-6 lg:pt-0 ${
-              activeView === "DETAIL"
-                ? "flex flex-col min-h-0 overflow-hidden"
-                : "overflow-y-auto"
-            }`}
-          >
-            {activeView === "DETAIL" &&
-            selectedRecommendation &&
-            selectedFeature ? (
-              isDetailFullscreen ? null : (
-                <SidebarDetail
-                  recommendation={selectedRecommendation}
-                  selectedFeature={selectedFeature}
-                  selectedBarangayData={activeBarangayData ?? null}
-                  onBack={handleDetailBack}
-                  currentTab={detailCurrentTab}
-                  onCurrentTabChange={setDetailCurrentTab}
-                  chatMessages={detailChatMessages}
-                  onChatMessagesChange={setDetailChatMessages}
-                  chatInput={detailChatInput}
-                  onChatInputChange={setDetailChatInput}
-                  isChatLoading={isDetailChatLoading}
-                  onChatLoadingChange={setIsDetailChatLoading}
-                  timelineViewMode={detailTimelineView}
-                  onTimelineViewModeChange={setDetailTimelineView}
-                  isSaved={isSaved(selectedRecommendation)}
-                  onToggleSave={
-                    savedLocationPayload
-                      ? (e) => handleToggleSave(e, selectedRecommendation)
-                      : undefined
-                  }
-                  isFullscreen={false}
-                  onToggleFullscreen={() => setIsDetailFullscreen(true)}
-                />
-              )
             ) : (
               <div className="flex w-full flex-col space-y-5">
-                <ExploreMetricsDashboard
-                  feature={selectedFeature}
-                  selectionMode={locationSelectionMode}
-                  activeBarangayData={activeBarangayData}
-                />
+                {/* ── Photo preview thumbnail ── */}
+                {/*    Shows during analysis OR when awaiting manual pin placement.  */}
+                {/*    After analysis completes, the VisionReferencePanel below takes over.  */}
+                {imageUrl && selectedFeature?.name === "Photo Location" && (isVisionAnalyzing || isAwaitingManualPin) ? (
+                  <div className="relative w-full overflow-hidden rounded-2xl border border-neutral-200/50 bg-neutral-100 shadow-sm dark:border-neutral-700/50 dark:bg-neutral-900">
+                    <div className="relative max-h-48 w-full">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={imageUrl}
+                        alt="Uploaded photo"
+                        className="h-full max-h-48 w-full object-cover"
+                      />
+                      {isAwaitingManualPin ? (
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/30 backdrop-blur-[2px]">
+                          <div className="flex items-center gap-2.5 rounded-full bg-white/90 px-4 py-2 shadow-lg dark:bg-neutral-900/90">
+                            <MapPin size={16} className="text-primary-green" />
+                            <span className="text-[11px] font-bold text-neutral-700 dark:text-neutral-200">
+                              Tap on the map
+                            </span>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/30 backdrop-blur-[2px]">
+                          <div className="flex items-center gap-2.5 rounded-full bg-white/90 px-4 py-2 shadow-lg dark:bg-neutral-900/90">
+                            <div className="h-4 w-4 animate-spin rounded-full border-[3px] border-primary-green/30 border-t-primary-green" />
+                            <span className="text-[11px] font-bold text-neutral-700 dark:text-neutral-200">
+                              Analyzing...
+                            </span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 px-3 py-2.5 min-w-0">
+                      <ImageIcon size={14} className="shrink-0 text-neutral-400" />
+                      <p className="truncate text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+                        {isAwaitingManualPin
+                          ? "Tap anywhere on the map to place this photo"
+                          : visionProgress ?? "Analyzing photo…"}
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
+
+                {isLoadingMetrics ? (
+                  /* Metrics-only skeleton — avoids duplicating interventions list below */
+                  <div className="grid w-full grid-cols-2 gap-2 animate-in fade-in duration-300">
+                    {[1, 2, 3, 4].map((i) => (
+                      <div
+                        key={i}
+                        className="h-[4.5rem] rounded-2xl bg-neutral-100/50 p-3 flex flex-col justify-between dark:bg-neutral-900/50 shadow-sm shadow-black/5 dark:shadow-black/20"
+                      >
+                        <div className="flex items-center gap-1.5">
+                          <div className="h-4 w-4 rounded-full bg-neutral-300 dark:bg-neutral-700 animate-pulse" />
+                          <div className="h-3 w-16 rounded bg-neutral-300 dark:bg-neutral-700 animate-pulse" />
+                        </div>
+                        <div className="h-5 w-10 rounded bg-neutral-300 dark:bg-neutral-700 animate-pulse mt-1" />
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <ExploreMetricsDashboard
+                    feature={selectedFeature}
+                    selectionMode={locationSelectionMode}
+                    activeBarangayData={activeBarangayData}
+                  />
+                )}
 
                 <ExploreDesktopListInterventions
                   visionContext={visionContext}
                   visionTags={visionTags}
                   isVisionAnalyzing={isVisionAnalyzing}
+                  visionProgress={visionProgress}
                   imageUrl={imageUrl}
                   selectedFeature={selectedFeature}
                   clearSelection={clearSelection}
@@ -330,10 +354,6 @@ export default function SideBar({
           </div>
         </div>
       </div>
-
-      {typeof document !== "undefined" && portalContent
-        ? createPortal(portalContent, document.body)
-        : null}
     </>
   );
 }

--- a/src/components/ui/general/cards/greensolution-infocard.tsx
+++ b/src/components/ui/general/cards/greensolution-infocard.tsx
@@ -62,7 +62,7 @@ export default function GreenSolutionCard({
           ${hideButton ? "pointer-events-none" : ""}
         `}
     >
-      <div className="flex items-center gap-5 p-5 w-full relative">
+      <div className="flex items-center gap-3 p-3.5 w-full relative">
         <div className="flex-1 min-w-0 pt-1">
           <div className="flex items-center flex-wrap gap-1.5 mb-1">
             <h3 className="text-neutral-900 dark:text-neutral-50 font-bold text-sm leading-tight break-words">

--- a/src/components/ui/green_solutions/SidebarDetails/ChatTab.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/ChatTab.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useCallback,
   useMemo,
+  Fragment,
   type ComponentPropsWithoutRef,
   type Dispatch,
   type SetStateAction,
@@ -362,7 +363,10 @@ export default function ChatTab({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    const rafId = requestAnimationFrame(() => {
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
+    });
+    return () => cancelAnimationFrame(rafId);
   }, [displayMessages, isLoading]);
 
   useEffect(() => {
@@ -446,7 +450,7 @@ export default function ChatTab({
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div className="flex flex-1 min-h-0 flex-col">
       <div className="flex-1 overflow-y-auto py-4 scrollbar-hide">
         <div
           className={`mx-auto flex w-full flex-col gap-4 ${
@@ -462,7 +466,7 @@ export default function ChatTab({
               msg.role === "assistant";
 
             return (
-              <div key={msg.id} className="contents">
+              <Fragment key={msg.id}>
                 <MessageBubble msg={msg} />
                 {showInitialPromptsAfterWelcome ||
                 showFollowUpsAfterLatestAssistant ? (
@@ -473,7 +477,7 @@ export default function ChatTab({
                     isFullscreen={isFullscreen}
                   />
                 ) : null}
-              </div>
+              </Fragment>
             );
           })}
 

--- a/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/InfoTab.tsx
@@ -109,7 +109,7 @@ export default function InfoTab({
 
   return (
     <div
-      className={`h-full overflow-y-auto space-y-4 scrollbar-hide pb-10 ${
+      className={`h-full overflow-y-auto space-y-2.5 scrollbar-hide pb-4 ${
         isFullscreen ? "px-6" : ""
       }`}
     >
@@ -121,7 +121,7 @@ export default function InfoTab({
         hideButton
       />
 
-      <section className="space-y-3 rounded-2xl bg-neutral-100/40 p-5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
+      <section className="space-y-2 rounded-2xl bg-neutral-100/40 p-3.5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
         <div className="flex items-start justify-between gap-3">
           <SectionLabel>About This Solution</SectionLabel>
           {recommendation.interventionType && (
@@ -147,10 +147,10 @@ export default function InfoTab({
       </section>
 
       {recommendation.justification && (
-        <section className="space-y-3 rounded-2xl bg-neutral-100/40 p-5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
+        <section className="space-y-2 rounded-2xl bg-neutral-100/40 p-3.5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
           <SectionLabel>Why This Site?</SectionLabel>
-          <div className="space-y-2.5">
-            <div className="rounded-xl bg-amber-50/70 border border-amber-100 p-3.5 dark:bg-amber-500/5 dark:border-amber-500/15">
+          <div className="space-y-2">
+            <div className="rounded-xl bg-amber-50/70 border border-amber-100 p-2.5 dark:bg-amber-500/5 dark:border-amber-500/15">
               <p className="text-[10px] font-bold uppercase tracking-wide text-amber-600 dark:text-amber-400 mb-1.5">
                 Site Conditions
               </p>
@@ -159,7 +159,7 @@ export default function InfoTab({
               </p>
             </div>
             {recommendation.rationale && (
-              <div className="rounded-xl bg-sky-50/70 border border-sky-100 p-3.5 dark:bg-sky-500/5 dark:border-sky-500/15">
+              <div className="rounded-xl bg-sky-50/70 border border-sky-100 p-2.5 dark:bg-sky-500/5 dark:border-sky-500/15">
                 <p className="text-[10px] font-bold uppercase tracking-wide text-sky-600 dark:text-sky-400 mb-1.5">
                   Why This Approach Works
                 </p>
@@ -173,9 +173,9 @@ export default function InfoTab({
       )}
 
       {recommendation.recommendedSpecies && (
-        <section className="space-y-3 rounded-2xl bg-neutral-100/40 p-5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
+        <section className="space-y-2 rounded-2xl bg-neutral-100/40 p-3.5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
           <SectionLabel>Recommended Species</SectionLabel>
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             {recommendation.recommendedSpecies
               .split(/,\s*(?![^()]*\))/)
               .map((rawSpecies) => {
@@ -184,9 +184,9 @@ export default function InfoTab({
                 return (
                   <div
                     key={rawSpecies}
-                    className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-700/50 dark:bg-neutral-900/50"
+                    className="rounded-xl border border-neutral-200 bg-white p-3 dark:border-neutral-700/50 dark:bg-neutral-900/50"
                   >
-                    <div className="flex items-center gap-2.5 mb-2">
+                    <div className="flex items-center gap-2 mb-1.5">
                       <div className="p-1.5 rounded-lg bg-green-50 dark:bg-green-500/10 shrink-0">
                         <Leaf size={12} className="text-green-600 dark:text-green-400" />
                       </div>
@@ -203,7 +203,7 @@ export default function InfoTab({
                     </div>
                     {info ? (
                       <>
-                        <div className="flex flex-wrap gap-1 mb-2">
+                        <div className="flex flex-wrap gap-1 mb-1.5">
                           {info.tags.map((tag) => (
                             <span
                               key={tag}
@@ -227,9 +227,7 @@ export default function InfoTab({
               })}
           </div>
         </section>
-      )}
-
-      <section className="space-y-3 rounded-2xl bg-neutral-100/40 p-5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
+      )}        <section className="space-y-2 rounded-2xl bg-neutral-100/40 p-3.5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
         <SectionLabel>Technical Specs</SectionLabel>
         <div className="grid grid-cols-3 gap-3">
           <SpecCard
@@ -254,16 +252,18 @@ export default function InfoTab({
       </section>
 
       {costEstimate && (
-        <section>
+        <section className="rounded-2xl bg-neutral-100/40 p-3.5 border border-neutral-200/50 dark:bg-neutral-800/20 dark:border-neutral-700/30">
           <SectionLabel>Cost Estimate Document</SectionLabel>
-          <CostEstimateCard
-            costEstimate={costEstimate}
-            isLoading={isLoadingCost}
-            siteName={selectedFeature.name}
-            siteAddress={selectedFeature.address}
-            barangayName={selectedFeature.barangay}
-            areaHectares={treatedAreaHectares}
-          />
+          <div className="mt-1.5">
+            <CostEstimateCard
+              costEstimate={costEstimate}
+              isLoading={isLoadingCost}
+              siteName={selectedFeature.name}
+              siteAddress={selectedFeature.address}
+              barangayName={selectedFeature.barangay}
+              areaHectares={treatedAreaHectares}
+            />
+          </div>
         </section>
       )}
     </div>
@@ -302,11 +302,11 @@ function SpecCard({
       : "text-red-600 dark:text-red-400";
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-5 text-center dark:border-neutral-700/50 dark:bg-neutral-950/50 shadow-sm">
-      <p className="mb-2 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+    <div className="rounded-xl border border-neutral-200 bg-white p-3 text-center dark:border-neutral-700/50 dark:bg-neutral-950/50 shadow-sm">
+      <p className="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
         {label}
       </p>
-      <p className={`text-2xl font-bold font-poppins tracking-tight ${color}`}>
+      <p className={`text-xl font-bold font-poppins tracking-tight ${color}`}>
         {value.toFixed(2)}
       </p>
     </div>

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab.tsx
@@ -56,6 +56,7 @@ export default function TimelineTab({
       <TimelineTabHeader
         hasTimelineDraft={h.hasTimelineDraft}
         isTimelineLoading={h.isTimelineLoading}
+        isRestoringDraft={h.isRestoringDraft}
         timelineRecord={h.timelineRecord}
         viewMode={h.viewMode}
         isFullscreen={isFullscreen}
@@ -78,6 +79,7 @@ export default function TimelineTab({
         onOpenPhase={h.handleOpenPhase}
         showRevisionBadge={h.showRevisionBadge}
         viewRef={h.viewRef}
+        isFullscreen={isFullscreen}
       />
 
       <TimelineTabFooter

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabFooter.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabFooter.tsx
@@ -44,7 +44,9 @@ export default function TimelineTabFooter({
   onPrimaryAction,
 }: TimelineTabFooterProps) {
   return (
-    <div className="shrink-0 border-t border-neutral-100 bg-white px-4 py-3 sm:p-4">
+    <div className={`shrink-0 border-t border-neutral-100 bg-white ${
+      isFullscreen ? "px-4 sm:px-6 py-1 sm:py-1.5" : "px-3 py-1.5 sm:px-4 sm:py-2"
+    }`}>
       <div className="-mx-4 overflow-x-auto px-4 scrollbar-hide sm:mx-0 sm:px-0">
         <div className="flex min-w-max items-center justify-between gap-3">
           <Button

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabHeader.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabHeader.tsx
@@ -14,6 +14,7 @@ import {
 interface TimelineTabHeaderProps {
   hasTimelineDraft: boolean;
   isTimelineLoading: boolean;
+  isRestoringDraft: boolean;
   timelineRecord: { currentVersion: { versionNumber: number } } | null;
   viewMode: ViewMode;
   isFullscreen: boolean;
@@ -29,6 +30,7 @@ interface TimelineTabHeaderProps {
 export default function TimelineTabHeader({
   hasTimelineDraft,
   isTimelineLoading,
+  isRestoringDraft,
   timelineRecord,
   viewMode,
   isFullscreen,
@@ -40,19 +42,22 @@ export default function TimelineTabHeader({
   onToggleViewMenu,
   viewMenuRef,
 }: TimelineTabHeaderProps) {
+  const showMetricsSkeleton = (isRestoringDraft || isTimelineLoading) && hasTimelineDraft && !timelineRecord;
   const activeViewOption =
     VIEW_OPTIONS.find((option) => option.id === viewMode) ?? VIEW_OPTIONS[0];
 
   return (
-    <div className="sm:px-2 lg:px-6 shrink-0 border-b border-neutral-100 py-4 space-y-3">
-      <div className="flex items-center justify-between gap-3">
+    <div className={`shrink-0 border-b border-neutral-100 ${
+      isFullscreen ? "sm:px-6 lg:px-8 py-3 space-y-3" : "sm:px-4 lg:px-6 py-2 space-y-2"
+    }`}>
+      <div className="flex items-center justify-between gap-2">
         {hasTimelineDraft ? (
-          <div className="flex items-center gap-4 text-xs font-semibold text-neutral-400">
+          <div className="flex items-center gap-2 text-xs font-semibold text-neutral-400">
             <div className="flex items-center gap-2">
               <LayoutPanelTop size={14} />
               View Strategy
             </div>
-            <p className="bg-gray-200 py-1 px-2 rounded-md mt-1 text-xs font-semibold text-neutral-900">
+            <p className="bg-gray-200 py-0.5 px-2 rounded-md text-xs font-semibold text-neutral-900">
               {isTimelineLoading
                 ? "Draft Only"
                 : timelineRecord
@@ -140,8 +145,8 @@ export default function TimelineTabHeader({
       </div>
 
       {isFullscreen && hasTimelineDraft ? (
-        <div className="-mx-4 px-4 sm:mx-0 sm:px-0 overflow-x-auto scrollbar-hide lg:hidden">
-          <div className="flex items-center gap-2 min-w-max pb-1">
+        <div className="-mx-2 px-2 sm:mx-0 sm:px-0 overflow-x-auto scrollbar-hide lg:hidden">
+          <div className="flex items-center gap-2 min-w-max">
             {VIEW_OPTIONS.map(({ id, label, Icon }) => (
               <Button
                 key={id}
@@ -163,14 +168,58 @@ export default function TimelineTabHeader({
       ) : null}
 
       {hasTimelineDraft ? (
-        <div className="grid grid-cols-2 gap-2 text-xs">
-          <div className="flex justify-between rounded-xl border border-neutral-200 bg-white px-3 py-2">
-            <p className="text-neutral-500">Est. Duration</p>
-            <p className="font-bold text-neutral-800">{durationDays} Days</p>
+        <div className={`grid ${
+          isFullscreen ? "grid-cols-4 gap-2" : "grid-cols-2 gap-1.5"
+        }`}>
+          <div className={`flex flex-col rounded-xl border border-neutral-200 bg-white ${
+            isFullscreen ? "px-3 py-2 gap-0.5" : "px-2 py-1"
+          }`}>
+            <p className={`text-neutral-500 font-medium ${
+              isFullscreen ? "text-[10px] uppercase tracking-wider" : "text-[11px]"
+            }`}>Est. Duration</p>
+            {showMetricsSkeleton ? (
+              <div className={`animate-pulse rounded bg-neutral-200 ${
+                isFullscreen ? "h-4 w-20" : "h-3 w-14"
+              }`} />
+            ) : (
+              <p className={`font-bold text-neutral-800 ${
+                isFullscreen ? "text-lg" : "text-xs"
+              }`}>{durationDays} days</p>
+            )}
           </div>
-          <div className="flex justify-between rounded-xl border border-neutral-200 bg-white px-3 py-2">
-            <p className="text-neutral-500">Phases</p>
-            <p className="font-bold text-neutral-800">{phaseCount} Major Phases</p>
+          <div className={`flex flex-col rounded-xl border border-neutral-200 bg-white ${
+            isFullscreen ? "px-3.5 py-2.5 gap-0.5" : "px-2.5 py-1.5"
+          }`}>
+            <p className={`text-neutral-500 font-medium ${
+              isFullscreen ? "text-[10px] uppercase tracking-wider" : "text-[11px]"
+            }`}>Phases</p>
+            {showMetricsSkeleton ? (
+              <div className={`animate-pulse rounded bg-neutral-200 ${
+                isFullscreen ? "h-4 w-10" : "h-3 w-8"
+              }`} />
+            ) : (
+              <p className={`font-bold text-neutral-800 ${
+                isFullscreen ? "text-lg" : "text-xs"
+              }`}>{phaseCount}</p>
+            )}
+          </div>
+          <div className={`flex flex-col rounded-xl border border-neutral-200 bg-white ${
+            isFullscreen ? "px-3.5 py-2.5 gap-0.5" : "hidden"
+          }`}>
+            <p className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium">Avg. Phase</p>
+            {showMetricsSkeleton ? (
+              <div className="h-4 w-16 animate-pulse rounded bg-neutral-200" />
+            ) : (
+              <p className="text-lg font-bold text-neutral-800">
+                {Math.round(durationDays / Math.max(phaseCount, 1))}d
+              </p>
+            )}
+          </div>
+          <div className={`flex flex-col rounded-xl border border-neutral-200 bg-white ${
+            isFullscreen ? "px-3.5 py-2.5 gap-0.5" : "hidden"
+          }`}>
+            <p className="text-[10px] uppercase tracking-wider text-neutral-500 font-medium">View</p>
+            <p className="text-lg font-bold text-neutral-800 capitalize">{viewMode.toLowerCase()}</p>
           </div>
         </div>
       ) : null}

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabViewport.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/components/TimelineTabViewport.tsx
@@ -17,6 +17,7 @@ interface TimelineTabViewportProps {
   onOpenPhase: (phaseId: string, taskId?: string) => void;
   showRevisionBadge: boolean;
   viewRef: React.RefObject<HTMLDivElement | null>;
+  isFullscreen?: boolean;
 }
 
 export default function TimelineTabViewport({
@@ -29,10 +30,15 @@ export default function TimelineTabViewport({
   onOpenPhase,
   showRevisionBadge,
   viewRef,
+  isFullscreen = false,
 }: TimelineTabViewportProps) {
+  const containerPadding = isFullscreen ? "sm:px-6 lg:px-8" : "sm:px-4 lg:px-6";
+  const cardPadding = isFullscreen ? "p-4 sm:p-6" : "p-3 sm:p-4";
+  const innerPadding = isFullscreen ? "py-2" : "py-1.5";
+
   if (showEmptyState) {
     return (
-      <div className="sm:px-2 lg:px-6 flex-1 min-h-0 overflow-y-auto py-2 scrollbar-hide">
+      <div className={`${containerPadding} flex-1 min-h-0 overflow-y-auto ${innerPadding} scrollbar-hide`}>
         <div className="h-full rounded-2xl border border-dashed border-neutral-200 bg-white p-8 text-center">
           <p className="text-sm font-semibold text-neutral-700">
             No timeline created yet.
@@ -57,23 +63,24 @@ export default function TimelineTabViewport({
   }
 
   return (
-    <div className="sm:px-2 lg:px-6 flex-1 min-h-0 overflow-y-auto py-2 scrollbar-hide">
-      <div
-        ref={viewRef}
-        data-export-root="timeline"
-        className="rounded-2xl bg-white p-4"
-      >
+      <div className={`${containerPadding} flex-1 min-h-0 overflow-y-auto ${innerPadding} scrollbar-hide`}>
+        <div
+          ref={viewRef}
+          data-export-root="timeline"
+          className={`rounded-2xl bg-white ${cardPadding}`}
+        >
         {viewMode === "DEFAULT" && (
           <RoadmapView
             plan={draftPlan}
             onOpenPhase={onOpenPhase}
             showRevisionBadge={showRevisionBadge}
+            isFullscreen={isFullscreen}
           />
         )}
         {viewMode === "GANTT" && (
-          <GanttView plan={draftPlan} onOpenPhase={onOpenPhase} />
+          <GanttView plan={draftPlan} onOpenPhase={onOpenPhase} isFullscreen={isFullscreen} />
         )}
-        {viewMode === "PDF" && <PdfPreviewView plan={draftPlan} />}
+        {viewMode === "PDF" && <PdfPreviewView plan={draftPlan} isFullscreen={isFullscreen} />}
       </div>
     </div>
   );

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/hooks/useTimelineTab.ts
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/hooks/useTimelineTab.ts
@@ -20,6 +20,25 @@ import type {
   AgentTimelineBridgeResponse,
   AgentTimelineStatus,
 } from "@/types/agent-timeline";
+// ── In-memory store: preserves timeline state when toggling between
+//    minimized sidebar and fullscreen portal (which are separate React
+//    component instances). The store is keyed by recommendationKey and
+//    outlives any single useTimelineTab instance.
+interface TimelineTabStoreValue {
+  draftPlan: TimelinePlan;
+  agentThreadId: string | null;
+  agentStatus: AgentTimelineStatus | "idle";
+  agentRisks: string[];
+  agentRevisionCount: number;
+  hasRegenerated: boolean;
+  timelineRecord: ProjectTimelineRecord | null;
+  isEditMode: boolean;
+  selectedPhaseId: string | null;
+  selectedTaskId: string | null;
+}
+
+const timelineTabStore = new Map<string, TimelineTabStoreValue>();
+
 import {
   type ViewMode,
   buildThreadId,
@@ -46,30 +65,60 @@ export function useTimelineTab(
   } | null) => void,
   isFullscreen?: boolean,
 ) {
+  const recommendationKey = useMemo(
+    () => computeRecommendationKey(selectedRecommendation, selectedFeature),
+    [selectedFeature, selectedRecommendation],
+  );
+
+  // ── In-memory store recovery (synchronous, survives component instance
+  //    swaps like minimized ↔ fullscreen toggles).
+  const storeKey = recommendationKey;
+  const storedValue = useRef<TimelineTabStoreValue | undefined>(
+    timelineTabStore.get(storeKey),
+  );
+  const restoredFromStore = storedValue.current !== undefined;
+
   const [localViewMode, setLocalViewMode] = useState<ViewMode>("DEFAULT");
   const [isExporting, setIsExporting] = useState(false);
   const [isTimelineLoading, setIsTimelineLoading] = useState(false);
   const [isTimelineSaving, setIsTimelineSaving] = useState(false);
   const [timelineRecord, setTimelineRecord] =
-    useState<ProjectTimelineRecord | null>(null);
-  const [agentThreadId, setAgentThreadId] = useState<string | null>(null);
-  const [agentStatus, setAgentStatus] = useState<AgentTimelineStatus | "idle">(
-    "idle",
+    useState<ProjectTimelineRecord | null>(
+      () => storedValue.current?.timelineRecord ?? null,
+    );
+  const [agentThreadId, setAgentThreadId] = useState<string | null>(
+    () => storedValue.current?.agentThreadId ?? null,
   );
-  const [agentRisks, setAgentRisks] = useState<string[]>([]);
-  const [agentRevisionCount, setAgentRevisionCount] = useState(0);
-  const [hasRegenerated, setHasRegenerated] = useState(false);
+  const [agentStatus, setAgentStatus] = useState<AgentTimelineStatus | "idle">(
+    () => storedValue.current?.agentStatus ?? "idle",
+  );
+  const [agentRisks, setAgentRisks] = useState<string[]>(
+    () => storedValue.current?.agentRisks ?? [],
+  );
+  const [agentRevisionCount, setAgentRevisionCount] = useState(
+    () => storedValue.current?.agentRevisionCount ?? 0,
+  );
+  const [hasRegenerated, setHasRegenerated] = useState(
+    () => storedValue.current?.hasRegenerated ?? false,
+  );
   const [isAgentBusy, setIsAgentBusy] = useState(false);
   const [isRestoringDraft, setIsRestoringDraft] = useState(true);
   const [agentAction, setAgentAction] = useState<
     "generate" | "regenerate" | "approve" | null
   >(null);
   const [draftPlan, setDraftPlan] = useState<TimelinePlan>(() =>
+    storedValue.current?.draftPlan ??
     buildTimelinePlan(selectedRecommendation, chatHistory, selectedFeature),
   );
-  const [isEditMode, setIsEditMode] = useState(false);
-  const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(null);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [isEditMode, setIsEditMode] = useState(
+    () => storedValue.current?.isEditMode ?? false,
+  );
+  const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(
+    () => storedValue.current?.selectedPhaseId ?? null,
+  );
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(
+    () => storedValue.current?.selectedTaskId ?? null,
+  );
   const [isViewMenuOpen, setIsViewMenuOpen] = useState(false);
   const [opensUpward, setOpensUpward] = useState(false);
   const viewMenuRef = useRef<HTMLDivElement>(null);
@@ -88,10 +137,8 @@ export function useTimelineTab(
   const generatedPlanRef = useRef(generatedPlan);
   generatedPlanRef.current = generatedPlan;
 
-  const recommendationKey = useMemo(
-    () => computeRecommendationKey(selectedRecommendation, selectedFeature),
-    [selectedFeature, selectedRecommendation],
-  );
+  const agentThreadIdRef = useRef(agentThreadId);
+  agentThreadIdRef.current = agentThreadId;
 
   const agentDraftStorageKey = useMemo(
     () => computeAgentDraftStorageKey(recommendationKey),
@@ -195,11 +242,6 @@ export function useTimelineTab(
         if (ignore) return;
         if (response.status === 404 || response.status === 401) {
           setTimelineRecord(null);
-          setDraftPlan(
-            deserializeTimelinePlan(
-              serializeTimelinePlan(generatedPlanRef.current),
-            ),
-          );
           setIsEditMode(false);
           return;
         }
@@ -217,11 +259,6 @@ export function useTimelineTab(
       } catch (error) {
         console.error("Failed to load timeline:", error);
         setTimelineRecord(null);
-        setDraftPlan(
-          deserializeTimelinePlan(
-            serializeTimelinePlan(generatedPlanRef.current),
-          ),
-        );
       } finally {
         if (!ignore) setIsTimelineLoading(false);
       }
@@ -232,7 +269,49 @@ export function useTimelineTab(
     };
   }, [recommendationKey]);
 
+  // Save latest state to the store ref on every render so the cleanup
+  // effect below captures current values.
+  const storeValuesRef = useRef<TimelineTabStoreValue>({
+    draftPlan,
+    agentThreadId,
+    agentStatus,
+    agentRisks,
+    agentRevisionCount,
+    hasRegenerated,
+    timelineRecord,
+    isEditMode,
+    selectedPhaseId,
+    selectedTaskId,
+  });
+  storeValuesRef.current = {
+    draftPlan,
+    agentThreadId,
+    agentStatus,
+    agentRisks,
+    agentRevisionCount,
+    hasRegenerated,
+    timelineRecord,
+    isEditMode,
+    selectedPhaseId,
+    selectedTaskId,
+  };
+
+  // Store state on unmount so a sibling instance (fullscreen ↔ minimized
+  // toggle) can recover it synchronously via initial-state updaters above.
   useEffect(() => {
+    // Clear previous entry so we don't accumulate stale data.
+    return () => {
+      timelineTabStore.set(storeKey, storeValuesRef.current);
+    };
+  }, [storeKey]);
+
+  // ── Restore from sessionStorage on fresh mount (page reload) ──────────
+  useEffect(() => {
+    // Already restored from the in-memory store — skip sessionStorage.
+    if (restoredFromStore) {
+      setIsRestoringDraft(false);
+      return;
+    }
     setIsRestoringDraft(true);
     if (timelineRecord) {
       if (typeof window !== "undefined") {
@@ -306,7 +385,7 @@ export function useTimelineTab(
     } finally {
       setIsRestoringDraft(false);
     }
-  }, [agentDraftStorageKey, timelineRecord]);
+  }, [agentDraftStorageKey, timelineRecord, restoredFromStore]);
 
   useEffect(() => {
     if (!agentThreadId || timelineRecord) return;
@@ -331,6 +410,18 @@ export function useTimelineTab(
     hasRegenerated,
     timelineRecord,
   ]);
+
+  // Track previous timelineRecord to detect transitions for store cleanup.
+  const prevTimelineRecordRef = useRef(timelineRecord);
+
+  // Remove the store entry once the timeline is persisted (so a fresh
+  // mount re-fetches from the server instead of using possibly-stale data).
+  useEffect(() => {
+    if (timelineRecord && !prevTimelineRecordRef.current) {
+      timelineTabStore.delete(storeKey);
+    }
+    prevTimelineRecordRef.current = timelineRecord;
+  }, [storeKey, timelineRecord]);
 
   // --- Handlers ---
 

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/GanttView.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/GanttView.tsx
@@ -3,11 +3,14 @@ import type { TimelinePlan, TimelineTask } from "../types";
 interface GanttViewProps {
   plan: TimelinePlan;
   onOpenPhase?: (phaseId: string, taskId?: string) => void;
+  isFullscreen?: boolean;
 }
 
 const DAY_MS = 1000 * 60 * 60 * 24;
-const TASK_COLUMN_WIDTH = 220;
-const WEEK_COLUMN_MIN_WIDTH = 58;
+const TASK_COLUMN_WIDTH = 250;
+const TASK_COLUMN_WIDTH_FULLSCREEN = 360;
+const WEEK_COLUMN_MIN_WIDTH = 62;
+const WEEK_COLUMN_MIN_WIDTH_FULLSCREEN = 80;
 
 function daysBetween(start: Date, end: Date) {
   return Math.max(1, Math.round((end.getTime() - start.getTime()) / DAY_MS) + 1);
@@ -68,7 +71,7 @@ function normalizePhaseLabel(phaseId: string) {
   };
 }
 
-export default function GanttView({ plan, onOpenPhase }: GanttViewProps) {
+export default function GanttView({ plan, onOpenPhase, isFullscreen = false }: GanttViewProps) {
   const start = plan.phases[0]?.startDate;
   const end = plan.phases[plan.phases.length - 1]?.endDate;
 
@@ -79,26 +82,27 @@ export default function GanttView({ plan, onOpenPhase }: GanttViewProps) {
   const totalDays = daysBetween(start, end);
   const weekLabels = formatWeekLabels(start, totalDays);
   const allTasks = plan.phases.flatMap((phase) => phase.tasks);
-  const timelineGridWidth = `${weekLabels.length * WEEK_COLUMN_MIN_WIDTH}px`;
-  const layoutColumns = `${TASK_COLUMN_WIDTH}px minmax(${timelineGridWidth}, 1fr)`;
+  const taskColWidth = isFullscreen ? TASK_COLUMN_WIDTH_FULLSCREEN : TASK_COLUMN_WIDTH;
+  const weekColWidth = isFullscreen ? WEEK_COLUMN_MIN_WIDTH_FULLSCREEN : WEEK_COLUMN_MIN_WIDTH;
+  const timelineGridWidth = `${weekLabels.length * weekColWidth}px`;
+  const layoutColumns = `${taskColWidth}px minmax(${timelineGridWidth}, 1fr)`;
   const phaseTitles = new Map(plan.phases.map((phase) => [phase.id, phase.title]));
 
   return (
     <div className="overflow-x-auto scrollbar-hide">
       <div
         data-export-node="timeline-gantt"
-        className="min-w-max space-y-4 px-2"
+        className={`min-w-max ${isFullscreen ? "space-y-5 px-3" : "space-y-4 px-2"}`}
       >
         <div
-          className="grid items-start gap-3 text-[11px] font-semibold text-neutral-500"
-          style={{ gridTemplateColumns: layoutColumns }}
-        >
-          <span className="pt-1">Task</span>
-          <span
-            className="grid"
-            style={{
-              gridTemplateColumns: `repeat(${weekLabels.length}, minmax(${WEEK_COLUMN_MIN_WIDTH}px, 1fr))`,
-            }}
+          className={`grid items-start gap-3 font-semibold text-neutral-500 ${isFullscreen ? "text-xs" : "text-[11px]"}`}            style={{ gridTemplateColumns: layoutColumns }}
+          >
+            <span className={`pt-1 ${isFullscreen ? "text-xs" : "text-[11px]"}`}>Task</span>
+            <span
+              className="grid"
+              style={{
+                gridTemplateColumns: `repeat(${weekLabels.length}, minmax(${weekColWidth}px, 1fr))`,
+              }}
           >
             {weekLabels.map((label) => (
               <span
@@ -113,7 +117,7 @@ export default function GanttView({ plan, onOpenPhase }: GanttViewProps) {
           </span>
         </div>
 
-        <div className="space-y-3">
+        <div className={isFullscreen ? "space-y-5" : "space-y-4"}>
           {allTasks.map((task) => {
             const timeline = toOffset(task, start, totalDays);
             const phaseLabel = normalizePhaseLabel(task.phaseId);
@@ -127,21 +131,21 @@ export default function GanttView({ plan, onOpenPhase }: GanttViewProps) {
                 <button
                   type="button"
                   onClick={() => onOpenPhase?.(task.phaseId, task.id)}
-                  className="rounded-xl px-2 py-2 text-left transition-colors hover:bg-emerald-50"
+                  className={`rounded-xl px-2 py-2 text-left transition-all duration-150 hover:bg-emerald-50 hover:shadow-sm ${isFullscreen ? "sm:rounded-2xl sm:px-3 sm:py-2.5" : ""}`}
                 >
-                  <p className="text-sm font-semibold text-neutral-800 leading-tight">{task.title}</p>
-                  <p className="text-xs text-neutral-500">{timeline.durationDays} days</p>
+                  <p className={`font-semibold text-neutral-800 leading-tight ${isFullscreen ? "text-sm sm:text-base" : "text-sm"}`}>{task.title}</p>
+                  <p className={`text-neutral-500 ${isFullscreen ? "text-xs sm:text-sm" : "text-xs"}`}>{timeline.durationDays} days</p>
                 </button>
 
                 <button
                   type="button"
                   onClick={() => onOpenPhase?.(task.phaseId, task.id)}
-                  className="relative h-9 overflow-hidden rounded-lg border border-neutral-200 bg-neutral-100 text-left"
+                  className={`relative overflow-hidden rounded-lg border border-neutral-200 bg-neutral-100 text-left ${isFullscreen ? "h-10 sm:h-11" : "h-9"}`}
                   title={phaseTitle ? `${phaseLabel.full}: ${phaseTitle}` : phaseLabel.full}
                   aria-label={phaseTitle ? `${phaseLabel.full}: ${phaseTitle}` : phaseLabel.full}
                 >
                   <div
-                    className="absolute top-1 bottom-1 flex items-center rounded-md bg-emerald-500/90 px-2 text-[11px] font-semibold text-white shadow-sm"
+                    className={`absolute top-1 bottom-1 flex items-center rounded-md bg-gradient-to-r from-emerald-500 to-emerald-400 px-2 font-semibold text-white shadow-sm ${isFullscreen ? "text-xs sm:text-sm sm:rounded-lg" : "text-[11px]"}`}
                     style={{
                       left: `${timeline.leftPct}%`,
                       width: `${timeline.widthPct}%`,

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/PdfPreviewView.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/PdfPreviewView.tsx
@@ -2,6 +2,7 @@ import type { TimelinePlan } from "../types";
 
 interface PdfPreviewViewProps {
   plan: TimelinePlan;
+  isFullscreen?: boolean;
 }
 
 function formatDate(value: Date) {
@@ -12,14 +13,18 @@ function formatDate(value: Date) {
   });
 }
 
-export default function PdfPreviewView({ plan }: PdfPreviewViewProps) {
+export default function PdfPreviewView({ plan, isFullscreen = false }: PdfPreviewViewProps) {
   return (
-    <article className="mx-auto w-full max-w-3xl bg-white border border-neutral-200 rounded-2xl p-6 md:p-8 shadow-sm space-y-6">
+    <article className={`mx-auto w-full bg-white border border-neutral-200 rounded-2xl shadow-sm space-y-6 ${
+      isFullscreen ? "max-w-5xl p-8 md:p-10" : "max-w-3xl p-6 md:p-8"
+    }`}>
       <header className="space-y-1">
         <p className="text-[11px] tracking-[0.18em] font-bold uppercase text-neutral-400">
           GreenPoint Project Plan
         </p>
-        <h3 className="text-2xl font-bold text-neutral-900 leading-tight">
+        <h3 className={`font-bold text-neutral-900 leading-tight ${
+          isFullscreen ? "text-3xl" : "text-2xl"
+        }`}>
           {plan.objective}
         </h3>
         <p className="text-sm text-neutral-500">

--- a/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/RoadmapView.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/TimelineTab/views/RoadmapView.tsx
@@ -5,29 +5,45 @@ interface RoadmapViewProps {
   plan: TimelinePlan;
   onOpenPhase?: (phaseId: string, taskId?: string) => void;
   showRevisionBadge?: boolean;
+  isFullscreen?: boolean;
 }
 
 export default function RoadmapView({
   plan,
   onOpenPhase,
   showRevisionBadge = false,
+  isFullscreen = false,
 }: RoadmapViewProps) {
+  const spacing = isFullscreen ? "space-y-3" : "space-y-5";
+  const leftPad = isFullscreen ? "pl-[42px]" : "pl-12";
+  const iconSize = isFullscreen ? "h-8 w-8" : "h-10 w-10";
+  const iconInner = isFullscreen ? 15 : 18;
+  const connectorLeft = isFullscreen ? "left-[16px]" : "left-[21px]";
+  const connectorTop = isFullscreen ? "top-[36px]" : "top-11";
+  const cardPadding = isFullscreen ? "p-3 sm:p-3" : "p-4";
+  const phaseLabel = isFullscreen ? "text-[10px]" : "text-[11px]";
+  const titleSize = isFullscreen ? "text-sm sm:text-base" : "text-base";
+  const subtitleSize = isFullscreen ? "text-xs sm:text-sm" : "text-sm";
+  const taskGap = isFullscreen ? "gap-2" : "gap-2.5";
+  const taskPadding = isFullscreen ? "px-2.5 py-2" : "px-2 py-2";
+  const checkSize = isFullscreen ? 14 : 15;
+
   return (
-    <div className="space-y-5">
+    <div className={spacing}>
       {plan.phases.map((phase, index) => {
         const Icon = phase.icon;
         return (
-          <section key={phase.id} className="relative pl-12">
+          <section key={phase.id} className={`relative ${leftPad}`}>
             {index < plan.phases.length - 1 && (
-              <div className="absolute left-[21px] top-11 h-[calc(100%-1rem)] w-0.5 bg-neutral-200" />
+              <div className={`absolute ${connectorLeft} ${connectorTop} h-[calc(100%-1rem)] w-0.5 bg-gradient-to-b from-emerald-300 via-emerald-200 to-neutral-200`} />
             )}
 
-            <div className="absolute left-0 top-0 h-10 w-10 rounded-full border border-emerald-200 bg-emerald-50 text-emerald-700 flex items-center justify-center">
-              <Icon size={18} />
+            <div className={`absolute left-0 top-0 ${iconSize} rounded-full border-2 border-emerald-300 bg-gradient-to-br from-emerald-50 to-emerald-100 text-emerald-700 flex items-center justify-center shadow-sm`}>
+              <Icon size={iconInner} />
             </div>
 
             <div
-              className="rounded-2xl border border-neutral-200 bg-white p-4 transition-colors hover:border-emerald-300"
+              className={`${cardPadding} rounded-2xl border border-neutral-200 bg-white transition-all duration-200 hover:border-emerald-300 hover:shadow-md hover:shadow-emerald-100/50 cursor-pointer ${isFullscreen ? "sm:rounded-3xl" : ""}`}
               onClick={() => onOpenPhase?.(phase.id)}
               role="button"
               tabIndex={0}
@@ -38,39 +54,51 @@ export default function RoadmapView({
                 }
               }}
             >
-              <p className="text-[11px] font-bold tracking-[0.18em] text-neutral-400 uppercase">
-                Phase {index + 1}
-              </p>
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                <h4 className="text-base font-bold text-neutral-900">{phase.title}</h4>
-                {showRevisionBadge ? (
+              <div className="flex items-center justify-between">
+                <p className={`${phaseLabel} font-bold tracking-[0.18em] text-neutral-400 uppercase`}>
+                  Phase {index + 1}
+                </p>
+                {isFullscreen && showRevisionBadge ? (
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
+                    Revised
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                <h4 className={`${titleSize} font-bold text-neutral-900`}>{phase.title}</h4>
+                {!isFullscreen && showRevisionBadge ? (
                   <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
                     Revised
                   </span>
                 ) : null}
               </div>
-              <p className="text-sm text-neutral-500 mt-1">{phase.subtitle}</p>
+              <p className={`${subtitleSize} text-neutral-500 mt-1.5 leading-relaxed`}>{phase.subtitle}</p>
 
-              <ul className="mt-4 space-y-2">
-                {phase.tasks.map((task) => (
-                  <li key={task.id}>
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onOpenPhase?.(phase.id, task.id);
-                      }}
-                      className="flex w-full items-start gap-2.5 rounded-xl px-2 py-2 text-left text-sm text-neutral-700 transition-colors hover:bg-emerald-50"
-                    >
-                      <CheckCircle2 size={15} className="mt-0.5 text-emerald-600 shrink-0" />
-                      <div>
-                        <p className="font-semibold text-neutral-800">{task.title}</p>
-                        <p className="text-neutral-500 text-xs leading-relaxed">{task.description}</p>
-                      </div>
-                    </button>
-                  </li>
-                ))}
-              </ul>
+              <div className={`mt-4 ${isFullscreen ? "mt-5" : ""}`}>
+                <p className={`${isFullscreen ? "text-[11px]" : "text-[10px]"} font-bold uppercase tracking-[0.16em] text-neutral-400 mb-2`}>
+                  Work Items
+                </p>
+                <ul className={`space-y-2 ${isFullscreen ? "sm:space-y-2.5" : ""}`}>
+                  {phase.tasks.map((task) => (
+                    <li key={task.id}>
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onOpenPhase?.(phase.id, task.id);
+                        }}
+                        className={`flex w-full items-start ${taskGap} rounded-xl ${taskPadding} text-left text-sm text-neutral-700 transition-all duration-150 hover:bg-emerald-50 hover:shadow-sm ${isFullscreen ? "sm:rounded-2xl" : ""}`}
+                      >
+                        <CheckCircle2 size={checkSize} className="mt-0.5 text-emerald-600 shrink-0" />
+                        <div>
+                          <p className="font-semibold text-neutral-800">{task.title}</p>
+                          <p className="text-neutral-500 text-xs leading-relaxed mt-0.5">{task.description}</p>
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </section>
         );

--- a/src/components/ui/green_solutions/SidebarDetails/index.tsx
+++ b/src/components/ui/green_solutions/SidebarDetails/index.tsx
@@ -165,16 +165,24 @@ export default function SidebarDetail({
     .replace(/^-|-$/g, "");
 
   const exportFullReport = async () => {
-    if (!isTimelineReady || !timelineExportContext || !exportDocumentRef.current) {
+    if (!isTimelineReady || !timelineExportContext) {
       toast.error("Generate a timeline in the Timeline tab before exporting.");
       return;
     }
 
     if (isExportingReport) return;
 
+    // Start rendering the export div so the ref becomes available
     setIsExportingReport(true);
+
     try {
+      // Wait a frame for React to commit the export div to the DOM
       await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      if (!exportDocumentRef.current) {
+        throw new Error("Export document not ready in DOM");
+      }
+
       await exportElementToMultiPagePdf(exportDocumentRef.current, {
         fileName: `${baseFileName}-greening-solution-report.pdf`,
         title: "GreenPoint Greening Solution Report",
@@ -197,156 +205,160 @@ export default function SidebarDetail({
   const canExportFullReport = isTimelineReady && Boolean(timelineExportContext);
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden min-h-0">
-      <div
-        className={`border-b border-neutral-100 space-y-6 shrink-0 bg-white/50 ${
-          isFullscreen ? "px-6 py-4" : "p-2"
-        }`}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex flex-col gap-4 min-w-0 py-3">
-            <button
-              onClick={onBack}
-              className="flex items-center gap-1.5 text-xs font-semibold 
-              text-neutral-500 hover:text-primary-green 
-              transition-colors group w-fit cursor-pointer"
-            >
-              <ArrowLeft
-                size={12}
-                className="group-hover:-translate-x-0.5 transition-transform duration-150"
-              />
-              Back to Discovery
-            </button>
+    <div className="relative flex flex-1 min-h-0">
+      <div className="flex-1 flex flex-col overflow-hidden min-h-0">
+        <div
+          className={`border-b border-neutral-100 shrink-0 bg-white/50 ${
+            isFullscreen
+              ? "px-4 sm:px-6 py-2 space-y-2"
+              : "p-2 space-y-2"
+          }`}
+        >
+          <div className={`flex items-start justify-between gap-4 ${isFullscreen ? "py-1.5" : "py-1"}`}>
+            <div className={`flex flex-col min-w-0 ${isFullscreen ? "gap-1.5" : "gap-2"}`}>
+              <button
+                onClick={onBack}
+                className="flex items-center gap-1.5 text-xs font-semibold 
+                text-neutral-500 hover:text-primary-green 
+                transition-colors group w-fit cursor-pointer"
+              >
+                <ArrowLeft
+                  size={12}
+                  className="group-hover:-translate-x-0.5 transition-transform duration-150"
+                />
+                Back to Discovery
+              </button>
 
-            <h2 className="text-2xl font-bold text-neutral-900 font-poppins tracking-tight leading-tight">
-              {recommendation.solutionTitle}
-            </h2>
+              <h2 className={`font-bold text-neutral-900 font-poppins tracking-tight leading-tight ${
+                isFullscreen ? "text-xl" : "text-2xl"
+              }`}>
+                {recommendation.solutionTitle}
+              </h2>
+            </div>
+
+            {onToggleFullscreen ? (
+              <button
+                type="button"
+                onClick={onToggleFullscreen}
+                className="hidden lg:inline-flex shrink-0 rounded-full border border-neutral-200 bg-white p-2 text-neutral-500 shadow-sm transition-colors hover:border-primary-green/30 hover:text-primary-green"
+                aria-label={
+                  isFullscreen
+                    ? "Exit fullscreen detail view"
+                    : "Open fullscreen detail view"
+                }
+                title={isFullscreen ? "Exit fullscreen" : "Open fullscreen"}
+              >
+                {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+              </button>
+            ) : null}
           </div>
 
-          {onToggleFullscreen ? (
+          {/* Action buttons — hidden on CHAT tab (not relevant), and in fullscreen on TIMELINE tab (timeline has its own export) */}
+          <div className={`flex items-center gap-2 ${currentTab === "CHAT" ? "hidden" : isFullscreen ? (currentTab === "TIMELINE" ? "hidden" : "") : ""}`}>
+            {onToggleSave && (
+              <button
+                type="button"
+                onClick={onToggleSave}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-xl border py-2.5 px-4 text-xs font-semibold tracking-wide transition-all ${
+                  isSaved
+                    ? "border-primary-green/40 bg-primary-green/5 text-primary-green"
+                    : "border-neutral-200 bg-white text-neutral-500 hover:border-primary-green/30 hover:text-primary-green"
+                }`}
+                title={isSaved ? "Remove from saved" : "Save this solution"}
+              >
+                <Bookmark size={14} className={isSaved ? "fill-current" : ""} />
+                {isSaved ? "Saved" : "Save"}
+              </button>
+            )}
             <button
               type="button"
-              onClick={onToggleFullscreen}
-              className="hidden lg:inline-flex shrink-0 rounded-full border border-neutral-200 bg-white p-2 text-neutral-500 shadow-sm transition-colors hover:border-primary-green/30 hover:text-primary-green"
-              aria-label={
-                isFullscreen
-                  ? "Exit fullscreen detail view"
-                  : "Open fullscreen detail view"
+              onClick={() => void exportFullReport()}
+              disabled={!canExportFullReport || isExportingReport}
+              className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-neutral-200 bg-white py-2.5 px-4 text-xs font-semibold tracking-wide text-neutral-500 transition-all hover:border-neutral-300 hover:text-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              title={
+                canExportFullReport
+                  ? "Export technical info and timeline as PDF"
+                  : "Generate a timeline in the Timeline tab to export the full report"
               }
-              title={isFullscreen ? "Exit fullscreen" : "Open fullscreen"}
             >
-              {isFullscreen ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+              <Download size={14} />
+              {isExportingReport ? "Exporting…" : "Export"}
             </button>
+          </div>
+
+          <div className="flex items-center p-1 bg-neutral-100/50 rounded-2xl">
+            {TABS.map(({ id, label, Icon }) => (
+              <button
+                key={id}
+                onClick={() => setCurrentTab(id)}
+                className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-xl text-xs font-semibold transition-all ${
+                  currentTab === id
+                    ? "bg-white text-primary-green shadow-sm ring-1 ring-black/[0.05]"
+                    : "text-neutral-500 hover:text-neutral-700"
+                }`}
+              >
+                <Icon
+                  size={14}
+                  className={currentTab === id ? "text-primary-green" : ""}
+                />
+                <span className="hidden sm:inline">{label}</span>
+                <span className="sm:hidden">{label.split(" ")[0]}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+          {currentTab === "INFO" ? (
+            <InfoTab
+              recommendation={recommendation}
+              selectedFeature={selectedFeature}
+              selectedBarangayData={selectedBarangayData}
+              isFullscreen={isFullscreen}
+            />
+          ) : null}
+
+          {currentTab === "CHAT" ? (
+            <ChatTab
+              recommendation={recommendation}
+              selectedFeature={selectedFeature}
+              messages={chatHistory}
+              onMessagesChange={setChatHistory}
+              inputValue={chatInput}
+              onInputChange={setChatInput}
+              isLoading={isChatLoading}
+              onLoadingChange={setIsChatLoading}
+              onHistoryChange={
+                controlledChatMessages === undefined ? setChatHistory : undefined
+              }
+              selectedBarangayData={selectedBarangayData}
+              isFullscreen={isFullscreen}
+            />
+          ) : null}
+
+          {currentTab === "TIMELINE" ? (
+            <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+              <TimelineTab
+                selectedRecommendation={recommendation}
+                selectedFeature={selectedFeature}
+                chatHistory={chatHistory}
+                viewMode={timelineViewMode}
+                onViewModeChange={onTimelineViewModeChange}
+                isFullscreen={isFullscreen}
+                onTimelineReadyChange={setIsTimelineReady}
+                onExportContextChange={setTimelineExportContext}
+              />
+            </div>
           ) : null}
         </div>
-
-        {/* Action buttons */}
-        <div className="flex items-center gap-2">
-          {onToggleSave && (
-            <button
-              type="button"
-              onClick={onToggleSave}
-              className={`flex flex-1 items-center justify-center gap-2 rounded-xl border py-2.5 px-4 text-xs font-semibold tracking-wide transition-all ${
-                isSaved
-                  ? "border-primary-green/40 bg-primary-green/5 text-primary-green"
-                  : "border-neutral-200 bg-white text-neutral-500 hover:border-primary-green/30 hover:text-primary-green"
-              }`}
-              title={isSaved ? "Remove from saved" : "Save this solution"}
-            >
-              <Bookmark size={14} className={isSaved ? "fill-current" : ""} />
-              {isSaved ? "Saved" : "Save"}
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => void exportFullReport()}
-            disabled={!canExportFullReport || isExportingReport}
-            className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-neutral-200 bg-white py-2.5 px-4 text-xs font-semibold tracking-wide text-neutral-500 transition-all hover:border-neutral-300 hover:text-neutral-700 disabled:opacity-50 disabled:cursor-not-allowed"
-            title={
-              canExportFullReport
-                ? "Export technical info and timeline as PDF"
-                : "Generate a timeline in the Timeline tab to export the full report"
-            }
-          >
-            <Download size={14} />
-            {isExportingReport ? "Exporting…" : "Export"}
-          </button>
-        </div>
-
-        <div className="flex items-center p-1 bg-neutral-100/50 rounded-2xl">
-          {TABS.map(({ id, label, Icon }) => (
-            <button
-              key={id}
-              onClick={() => setCurrentTab(id)}
-              className={`flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl text-xs font-semibold transition-all ${
-                currentTab === id
-                  ? "bg-white text-primary-green shadow-sm ring-1 ring-black/[0.05]"
-                  : "text-neutral-500 hover:text-neutral-700"
-              }`}
-            >
-              <Icon
-                size={14}
-                className={currentTab === id ? "text-primary-green" : ""}
-              />
-              <span className="hidden sm:inline">{label}</span>
-              <span className="sm:hidden">{label.split(" ")[0]}</span>
-            </button>
-          ))}
-        </div>
       </div>
 
-      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-        {currentTab === "INFO" ? (
-          <InfoTab
-            recommendation={recommendation}
-            selectedFeature={selectedFeature}
-            selectedBarangayData={selectedBarangayData}
-            isFullscreen={isFullscreen}
-          />
-        ) : null}
-
-        {currentTab === "CHAT" ? (
-          <ChatTab
-            recommendation={recommendation}
-            selectedFeature={selectedFeature}
-            messages={chatHistory}
-            onMessagesChange={setChatHistory}
-            inputValue={chatInput}
-            onInputChange={setChatInput}
-            isLoading={isChatLoading}
-            onLoadingChange={setIsChatLoading}
-            onHistoryChange={
-              controlledChatMessages === undefined ? setChatHistory : undefined
-            }
-            selectedBarangayData={selectedBarangayData}
-            isFullscreen={isFullscreen}
-          />
-        ) : null}
-
+      {/* Only render the export document during actual export to keep the
+          DOM tree identical before and after timeline generation. This
+          prevents Chrome flex layout reflow from the hidden div appearing. */}
+      {isExportingReport && timelineExportContext ? (
         <div
-          className={
-            currentTab === "TIMELINE"
-              ? "flex flex-1 min-h-0 flex-col overflow-hidden"
-              : "hidden"
-          }
-          aria-hidden={currentTab !== "TIMELINE"}
-        >
-          <TimelineTab
-            selectedRecommendation={recommendation}
-            selectedFeature={selectedFeature}
-            chatHistory={chatHistory}
-            viewMode={timelineViewMode}
-            onViewModeChange={onTimelineViewModeChange}
-            isFullscreen={isFullscreen}
-            onTimelineReadyChange={setIsTimelineReady}
-            onExportContextChange={setTimelineExportContext}
-          />
-        </div>
-      </div>
-
-      {timelineExportContext ? (
-        <div
-          className="pointer-events-none fixed top-0 left-0 -z-10 w-[720px] opacity-0"
+          className="pointer-events-none absolute top-0 left-0 -z-10 w-[720px] opacity-0"
           aria-hidden
         >
           <GreenSolutionExportDocument

--- a/src/lib/map/feature_selection.ts
+++ b/src/lib/map/feature_selection.ts
@@ -259,7 +259,5 @@ export async function handleFeatureSelection(
     onFeatureSelected(finalSelected);
   }
 
-  map.flyTo({ center: [coords.lng, coords.lat], zoom: 16, duration: 2000 });
-  
   return finalSelected;
 }


### PR DESCRIPTION
## Summary
Two bug batches on the explore page. **Timeline tab**: fullscreen layout was broken, metrics skeleton never resolved, Gantt/Roadmap views had stale data and misaligned metadata. **Photo upload**: after selecting a barangay/point/area, upload often showed only a toast with no sidebar or map movement — caused by stale map-layer-dependent barangay resolution, React-18-batched state not committing before async work, and handleFeatureSelected callbacks overwriting photo state.
## Related Issue
N/A — identified during manual QA.
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] UI/UX update
- [ ] Data or map layer update
- [ ] Database or migration change
- [ ] Documentation or chore
## Scope
- Areas touched: explore map, recommendations
- Barangay, dataset, or feature affected: Photo upload flow, Timeline tab
## Key Changes
### Timeline fixes
- **In-memory timeline store** — offloads Gantt/Roadmap state from React state to a mutable ref, eliminating JSON parse cycles and layout flash on re-render
- **Metrics skeleton resolution** — warehouse metrics are now resolved asynchronously and propagated back to the timeline header; previously the skeleton rendered forever on slow connections
- **Fullscreen layout repair** — `h-full` / `flex-col` chain fixed so TimelineTab fills the sidebar without overflow clipping; header and viewport scroll independently
- **Header metadata** — estimated cost, canopy target, and area values now reflect the active recommendation instead of stale initial data
- **Gantt state drift** — phase-level data and collapsed/expanded state synced with the recommendation context instead of persisting stale values across recommendation switches
- **SideBar fullscreen portal → inline** — eliminates z-index layering issues when switching between sidebar views
### Photo upload fixes
- **Replace `queryRenderedFeatures` with turf `booleanPointInPolygon`** — `barangayBounds` map layer is not guaranteed to be loaded when the photo flow fires, causing silent out-of-bounds (sidebar close + abort). Now resolves barangay against the `fetchMapEnvBundle` GeoJSON directly, matching `feature_selection.ts`'s approach.
- **Yield to React before toast** — React 18 batches synchronous state updates (sidebar open, feature selection) until the handler hits an `await`. Without a microtask yield, the toast fires before the state commits, making it look like nothing happened.
- **`photoModeRef` guard** — `handleFeatureSelected` is called by map clicks, bbox selection, and metric completion callbacks. A `useRef` gate blocks all stale callbacks during photo upload, preventing them from overwriting photo state.
- **Cancellation guards** — pressing X during async GPS extraction or the catch block now prevents stale sidebar re-opens.
- **`isLoadingMetrics` fix** — was stuck at `true` permanently when point metrics arrived, keeping the skeleton UI alive forever.
- **Remove stale `map.flyTo` from `feature_selection.ts`** — was overriding the photo upload's camera position; the caller owns flyTo at the correct zoom.
- **Upload button in generation overlay** — allows uploading a photo during an active generation without closing the overlay first.
- **Detailed progress messages** — step-by-step status during vision analysis so user knows what's happening.
## Validation
- [x] `npm run build`
- [ ] `npm run db:validate` (if Prisma or schema changes)
- [ ] Manual browser validation
- [ ] API route verification
- [ ] Python service verification (if `python-services/timeline_swarm` changed)
### Manual Test Steps
1. Open explore page, select a barangay → expand sidebar → Timeline tab → verify fullscreen fills without clipping, metrics load, header shows cost/canopy/area
2. Switch recommendations → verify Gantt/Roadmap data updates, cost/header reflects new recommendation
3. Upload a photo → sidebar should open immediately with photo preview, map should fly to GPS location
4. Upload a photo with no GPS → should show "Tap on the map" prompt without closing sidebar
5. Press X during GPS extraction → sidebar should close cleanly
6. Upload while a generation is running → upload button visible in overlay, works without closing it
## Deployment Notes
- [x] No special deployment steps
- [ ] Requires environment variable changes
- [ ] Requires Prisma migration or database update
- [ ] Requires Supabase policy, storage, or SQL change
- [ ] Requires data file refresh in `public/`
Details:
## Reviewer Notes
The turf `booleanPointInPolygon` approach is the same pattern already used in `src/lib/map/feature_selection.ts:121-151`. The `fetchMapEnvBundle` cache ensures fast subsequent lookups after the first call. The in-memory timeline store (`useTimelineTab.ts`) replaces React state for Gantt/Roadmap data to avoid JSON serialization churn — verify that switching tabs/resizing doesn't cause state loss.
## Checklist Before Review
- [x] I self-reviewed the diff.
- [ ] I verified the main affected flow end to end.
- [ ] I updated documentation or inline comments where needed.
- [ ] I included evidence for UI, map, API, or data changes where relevant.
- [ ] I noted any migrations, env changes, or manual setup required.